### PR TITLE
Inject stable LITELLM_SALT_KEY from keychain

### DIFF
--- a/Sources/ErrandDesktop/App/AppState.swift
+++ b/Sources/ErrandDesktop/App/AppState.swift
@@ -170,8 +170,10 @@ class AppState: ObservableObject {
             do {
                 let encKey = try KeychainManager.getOrCreate(account: "credential-encryption-key")
                 let masterKey = try KeychainManager.getOrCreateLiteLLMKey()
+                let saltKey = try KeychainManager.getOrCreateLiteLLMSaltKey()
                 await containerEngine?.setCredentialEncryptionKey(encKey)
                 await containerEngine?.setLiteLLMMasterKey(masterKey)
+                await containerEngine?.setLiteLLMSaltKey(saltKey)
                 litellmMasterKeyDisplay = masterKey
                 appendLog(service: "system", message: "Keychain secrets loaded successfully")
                 return

--- a/Sources/ErrandDesktop/App/AppState.swift
+++ b/Sources/ErrandDesktop/App/AppState.swift
@@ -159,8 +159,9 @@ class AppState: ObservableObject {
         }
     }
 
-    /// Loads credential encryption key and LiteLLM master key from the macOS Keychain.
-    /// Retries up to 3 times with a 1-second delay (the keychain may be briefly locked after login).
+    /// Loads the credential encryption key, LiteLLM master key, and LiteLLM salt key
+    /// from the macOS Keychain. Retries up to 3 times with a 1-second delay (the keychain
+    /// may be briefly locked after login).
     /// Sets `keychainError` if all attempts fail — callers must check this before starting containers.
     private func loadKeychainSecrets() async {
         keychainError = nil

--- a/Sources/ErrandDesktop/Container/ContainerEngine.swift
+++ b/Sources/ErrandDesktop/Container/ContainerEngine.swift
@@ -57,6 +57,10 @@ actor ContainerEngine {
     /// LiteLLM master key from Keychain, used as the LiteLLM API key for all containers.
     var litellmMasterKey: String = ""
 
+    /// Stable LiteLLM salt key from Keychain, passed as `LITELLM_SALT_KEY` so that
+    /// values encrypted in the database remain decryptable across container restarts.
+    var litellmSaltKey: String = ""
+
     /// Scoped LiteLLM service key for Backend/Worker containers.
     private(set) var errandServiceKey: String = ""
 
@@ -79,6 +83,10 @@ actor ContainerEngine {
 
     func setLiteLLMMasterKey(_ key: String) {
         self.litellmMasterKey = key
+    }
+
+    func setLiteLLMSaltKey(_ key: String) {
+        self.litellmSaltKey = key
     }
 
     // MARK: - Service Key Provisioning
@@ -1152,6 +1160,9 @@ actor ContainerEngine {
                 env["LITELLM_MASTER_KEY"] = litellmMasterKey
                 env["UI_USERNAME"] = "admin"
                 env["UI_PASSWORD"] = litellmMasterKey
+            }
+            if !litellmSaltKey.isEmpty {
+                env["LITELLM_SALT_KEY"] = litellmSaltKey
             }
             env["LITELLM_MODE"] = "PRODUCTION"
             env["LITELLM_PROXY_CONNECTION_TIMEOUT"] = "600"

--- a/Sources/ErrandDesktop/Storage/KeychainManager.swift
+++ b/Sources/ErrandDesktop/Storage/KeychainManager.swift
@@ -46,7 +46,7 @@ enum KeychainManager {
         if let existing = try get(account: "litellm-master-key") {
             return existing
         }
-        let key = generateLiteLLMKey()
+        let key = try generateLiteLLMKey()
         try set(account: "litellm-master-key", value: key)
         return key
     }
@@ -159,10 +159,10 @@ enum KeychainManager {
     }
 
     /// Generates a LiteLLM-compatible API key in the format `sk-<18 alphanumeric chars>`.
-    static func generateLiteLLMKey() -> String {
+    /// Throws on RNG failure rather than minting a deterministic key from a zeroed buffer.
+    static func generateLiteLLMKey() throws -> String {
         let chars = Array("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-        var bytes = [UInt8](repeating: 0, count: 18)
-        _ = SecRandomCopyBytes(kSecRandomDefault, 18, &bytes)
+        let bytes = try secureRandomBytes(count: 18)
         let suffix = String(bytes.map { chars[Int($0) % chars.count] })
         return "sk-\(suffix)"
     }

--- a/Sources/ErrandDesktop/Storage/KeychainManager.swift
+++ b/Sources/ErrandDesktop/Storage/KeychainManager.swift
@@ -51,6 +51,20 @@ enum KeychainManager {
         return key
     }
 
+    /// Retrieves the LiteLLM salt key, or creates a stable 32-byte hex value
+    /// (equivalent to `openssl rand -hex 32`). Without a stable `LITELLM_SALT_KEY`,
+    /// LiteLLM generates a random salt on every startup and previously-encrypted
+    /// values stored in the database (model api_keys, api_bases, SMTP creds, etc.)
+    /// fail to decrypt with `nacl.exceptions.CryptoError`.
+    static func getOrCreateLiteLLMSaltKey() throws -> String {
+        if let existing = try get(account: "litellm-salt-key") {
+            return existing
+        }
+        let key = generateHexKey(bytesCount: 32)
+        try set(account: "litellm-salt-key", value: key)
+        return key
+    }
+
     /// Retrieves a secret by account name. Returns nil if not found.
     static func get(account: String) throws -> String? {
         // Try the file cache first (immune to code signature changes).
@@ -119,6 +133,13 @@ enum KeychainManager {
         var bytes = [UInt8](repeating: 0, count: bytesCount)
         _ = SecRandomCopyBytes(kSecRandomDefault, bytesCount, &bytes)
         return Data(bytes).base64EncodedString()
+    }
+
+    /// Generates a hex-encoded random key (equivalent to `openssl rand -hex <bytesCount>`).
+    private static func generateHexKey(bytesCount: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: bytesCount)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytesCount, &bytes)
+        return bytes.map { String(format: "%02x", $0) }.joined()
     }
 
     /// Generates a LiteLLM-compatible API key in the format `sk-<18 alphanumeric chars>`.

--- a/Sources/ErrandDesktop/Storage/KeychainManager.swift
+++ b/Sources/ErrandDesktop/Storage/KeychainManager.swift
@@ -36,7 +36,7 @@ enum KeychainManager {
         if let existing = try get(account: account) {
             return existing
         }
-        let key = generateRandomKey(bytesCount: bytesCount)
+        let key = try generateRandomKey(bytesCount: bytesCount)
         try set(account: account, value: key)
         return key
     }
@@ -60,12 +60,15 @@ enum KeychainManager {
         if let existing = try get(account: "litellm-salt-key") {
             return existing
         }
-        let key = generateHexKey(bytesCount: 32)
+        let key = try generateHexKey(bytesCount: 32)
         try set(account: "litellm-salt-key", value: key)
         return key
     }
 
     /// Retrieves a secret by account name. Returns nil if not found.
+    /// Throws on a locked keychain rather than reporting "not found", so that
+    /// `getOrCreate*` helpers do not silently mint a replacement key when the
+    /// existing one is merely temporarily inaccessible.
     static func get(account: String) throws -> String? {
         // Try the file cache first (immune to code signature changes).
         if let value = readFromFile(account: account) {
@@ -80,8 +83,14 @@ enum KeychainManager {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        if status == errSecItemNotFound || status == errSecInteractionNotAllowed {
+        if status == errSecItemNotFound {
             return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            // Keychain is locked. Surface this as an error so callers retry
+            // (loadKeychainSecrets has built-in retry) instead of treating
+            // it as "no entry exists" and rotating the key.
+            throw KeychainError.unhandledError(status: status)
         }
         guard status == errSecSuccess, let data = result as? Data,
               let value = String(data: data, encoding: .utf8) else {
@@ -129,17 +138,24 @@ enum KeychainManager {
 
     // MARK: - Key Generation
 
-    private static func generateRandomKey(bytesCount: Int) -> String {
-        var bytes = [UInt8](repeating: 0, count: bytesCount)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytesCount, &bytes)
-        return Data(bytes).base64EncodedString()
+    private static func generateRandomKey(bytesCount: Int) throws -> String {
+        return Data(try secureRandomBytes(count: bytesCount)).base64EncodedString()
     }
 
     /// Generates a hex-encoded random key (equivalent to `openssl rand -hex <bytesCount>`).
-    private static func generateHexKey(bytesCount: Int) -> String {
-        var bytes = [UInt8](repeating: 0, count: bytesCount)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytesCount, &bytes)
-        return bytes.map { String(format: "%02x", $0) }.joined()
+    private static func generateHexKey(bytesCount: Int) throws -> String {
+        return try secureRandomBytes(count: bytesCount).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Wraps `SecRandomCopyBytes` and propagates RNG failure rather than
+    /// silently returning a zeroed buffer.
+    private static func secureRandomBytes(count: Int) throws -> [UInt8] {
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        guard status == errSecSuccess else {
+            throw KeychainError.unhandledError(status: status)
+        }
+        return bytes
     }
 
     /// Generates a LiteLLM-compatible API key in the format `sk-<18 alphanumeric chars>`.


### PR DESCRIPTION
## Summary
- Without `LITELLM_SALT_KEY`, LiteLLM mints a random salt on every startup, so any value encrypted into the database (model api_keys, api_bases, SMTP creds, etc.) becomes undecryptable on the next run with `nacl.exceptions.CryptoError: Decryption failed. Ciphertext failed verification`.
- Mirrors the fix already applied to the K8s deployment (`litellm-k3s-rpi-values.yaml`): mint a stable 32-byte hex value on first run, store it in the macOS keychain alongside the existing master key, and inject it as `LITELLM_SALT_KEY` into the litellm container on every start.

## Changes
- `KeychainManager.swift` — new `getOrCreateLiteLLMSaltKey()` and a hex generator (equivalent to `openssl rand -hex 32`).
- `ContainerEngine.swift` — new `litellmSaltKey` field + setter; env var injected into `buildEnv` for the litellm case alongside the existing `LITELLM_MASTER_KEY` etc.
- `AppState.swift` — load the salt key during `loadKeychainSecrets()` and push it to the engine.

## Test plan
- [x] `swift build` clean
- [x] `make run`: keychain item `litellm-salt-key` materialised at `~/Library/Application Support/ErrandDesktop/secrets/litellm-salt-key` (64 hex chars)
- [x] LiteLLM container boots and serves traffic; UI login + `/health/latest` return 200
- [x] Save a model in the LiteLLM UI, restart the app, verify the model still decrypts

## Caveat
Rows already encrypted with the previous random salt remain undecryptable — there's no way to recover the prior random salt. Users will see lingering decryption errors at startup for legacy rows; re-saving each via the LiteLLM UI re-encrypts them under the stable salt and stops the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)