### PR TITLE
Default LiteLLM models without a mode tag to chat

### DIFF
--- a/Sources/ErrandDesktop/App/AppState.swift
+++ b/Sources/ErrandDesktop/App/AppState.swift
@@ -537,10 +537,15 @@ class AppState: ObservableObject {
                 let modelInfo = model["model_info"] as? [String: Any]
                 let mode = modelInfo?["mode"] as? String ?? ""
                 let info = ModelInfo(id: name, mode: mode)
+                // LiteLLM only sets `mode` on `model_info` when the user (or
+                // provider metadata) explicitly tags it. Treat missing/unknown
+                // modes as chat so models added via the LiteLLM UI without a
+                // mode tag still appear in the picker. Embeddings are still
+                // gated on an explicit `embedding` tag to avoid mis-listing
+                // chat models in the embedding dropdown.
                 switch mode {
-                case "chat": chat.append(info)
                 case "embedding": embedding.append(info)
-                default: break
+                default: chat.append(info)
                 }
             }
             return (chat, embedding)


### PR DESCRIPTION
## Summary
The Memory settings page was only showing one model when LiteLLM had three configured. Root cause: LiteLLM's `/model/info` only includes `model_info.mode` when the user (or provider metadata) explicitly tags it. Models added via the LiteLLM UI without a mode tag come back with `mode=null`, and the strict filter

```swift
switch mode {
case "chat": chat.append(info)
case "embedding": embedding.append(info)
default: break  // ← silently dropped
}
```

was discarding them entirely — not a refresh bug, a filter bug.

## Fix
Treat missing/unknown modes as chat. Embeddings remain gated on an explicit `embedding` tag so chat models don't accidentally end up in the embedding dropdown.

## Verification
With my local LiteLLM (`/model/info` returns 3 models, only `openrouter/openrouter/free` has `mode: "chat"`; the other two have `mode: null`):
- Before: 1 model in chat picker, 0 in embedding picker
- After: 3 models in chat picker, 0 in embedding picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)