### PR TITLE
Raise task-runner memory to 2 GiB to stop OOM kills

### DIFF
--- a/Sources/ErrandDesktop/Container/ContainerEngine.swift
+++ b/Sources/ErrandDesktop/Container/ContainerEngine.swift
@@ -809,8 +809,11 @@ actor ContainerEngine {
                 outputDir.path: "/output",
             ],
             network: "errand",
-            cpus: 1,
-            memoryInBytes: 256 * 1024 * 1024,
+            cpus: 2,
+            // Task-runner needs headroom for the Python interpreter, OpenAI/Anthropic
+            // SDKs, an MCP client, the tool catalog, and buffering for a 16k-token
+            // LLM context. 256 MiB OOM-kills the container (exit 137) on real tasks.
+            memoryInBytes: 2 * 1024 * 1024 * 1024,
             rootfsSizeInBytes: 2 * 1024 * 1024 * 1024
         )
 


### PR DESCRIPTION
## Summary
Task-runner containers were OOM-killed (exit 137) shortly after starting an LLM turn. Symptom in the desktop logs:

\`\`\`
[BridgeServer] createTaskContainer image=...errand-task-runner:0.119.4
[task-...] Connected to MCP server 'playwright' at http://192.168.64.2:3000/mcp
[task-...] {"type": "llm_turn_start", "data": {"model": "openai/gpt-oss-120b:free"}}
[AppleContainerRuntime] Container task-... EXITED with code 137
[BridgeServer] GET /containers/task-.../output → 404
[errand-backend] requests.exceptions.HTTPError: 404 Client Error: Not Found for url: .../output
[errand-backend] Task ... scheduled for retry
\`\`\`

Root cause: `BridgeServer.createTaskContainer` set `memoryInBytes = 256 * 1024 * 1024`. 256 MiB cannot hold the Python interpreter, the OpenAI/Anthropic SDKs over `httpx`, an MCP client + tool catalog, and buffering for a 16k-token LLM context.

## Fix
- `memoryInBytes`: 256 MiB → 2 GiB (the default for `ContainerConfig` is 1 GiB; task-runner needs more headroom than the long-running service containers)
- `cpus`: 1 → 2 (task-runner does meaningful concurrent work across LLM streaming, MCP traffic, and tool execution)

## Test plan
- [x] `swift build` succeeds
- [ ] `make run` then submit a task: container does not exit 137; `/output/result.json` is written; task completes