### PR TITLE
Distribute via Homebrew as a universal macOS 15+ build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,26 +21,21 @@ jobs:
         run: swift test
 
   release:
-    name: Release (${{ matrix.arch }})
+    name: Release (universal)
     needs: build-and-test
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    # Apple Silicon runner: the x86_64 slice is cross-compiled, so no Intel runner
+    # is required. The toolchain here must be able to target macOS 15 (Sequoia).
     runs-on: m4-max
     permissions:
       contents: write
-    strategy:
-      matrix:
-        include:
-          - arch: arm64
-            swift_arch: arm64
-            dmg_suffix: apple-silicon
-          - arch: x86_64
-            swift_arch: x86_64
-            dmg_suffix: intel
     steps:
       - uses: actions/checkout@v7
 
-      - name: Build release binary
-        run: swift build -c release --arch ${{ matrix.swift_arch }}
+      - name: Build universal release binary
+        run: |
+          chmod +x scripts/build-universal.sh
+          scripts/build-universal.sh .build/universal/ErrandDesktop
 
       - name: Create app bundle
         env:
@@ -48,7 +43,7 @@ jobs:
         run: |
           APP_DIR="ErrandDesktop.app/Contents/MacOS"
           mkdir -p "$APP_DIR"
-          cp .build/release/ErrandDesktop "$APP_DIR/"
+          cp .build/universal/ErrandDesktop "$APP_DIR/"
 
           TAG="$REF_NAME"
           VERSION="${TAG#v}"
@@ -72,7 +67,7 @@ jobs:
               <key>CFBundleShortVersionString</key>
               <string>${VERSION}</string>
               <key>LSMinimumSystemVersion</key>
-              <string>26.0</string>
+              <string>15.0</string>
               <key>LSUIElement</key>
               <true/>
               <key>CFBundleIconFile</key>
@@ -90,6 +85,23 @@ jobs:
           mkdir -p "$BUNDLE_DIR"
           cp Sources/ErrandDesktop/Resources/*.png "$BUNDLE_DIR/"
           cp Sources/ErrandDesktop/Resources/AppIcon.icns "$RESOURCES_DIR/"
+
+      - name: Verify bundle is universal and targets macOS 15
+        run: |
+          lipo -info "ErrandDesktop.app/Contents/MacOS/ErrandDesktop"
+          ARCHS="$(lipo -archs 'ErrandDesktop.app/Contents/MacOS/ErrandDesktop')"
+          for expected in arm64 x86_64; do
+            case " $ARCHS " in
+              *" $expected "*) ;;
+              *) echo "error: app binary is missing the $expected slice (got: $ARCHS)" >&2; exit 1 ;;
+            esac
+          done
+
+          MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' 'ErrandDesktop.app/Contents/Info.plist')"
+          if [[ "$MIN" != "15.0" ]]; then
+            echo "error: LSMinimumSystemVersion is '$MIN', expected '15.0'" >&2
+            exit 1
+          fi
 
       - name: Import signing certificate
         env:
@@ -122,51 +134,62 @@ jobs:
 
       - name: Sign app bundle
         run: |
-          codesign --deep --force --verify --verbose \
+          # Sign the universal binary in place first, then the .app wrapper.
+          # Both slices are covered by a single signature on the fat Mach-O.
+          codesign --force --verify --verbose \
+            --sign "Developer ID Application" \
+            --options runtime \
+            --entitlements ErrandDesktop.entitlements \
+            "ErrandDesktop.app/Contents/MacOS/ErrandDesktop"
+
+          codesign --force --verify --verbose \
             --sign "Developer ID Application" \
             --options runtime \
             --entitlements ErrandDesktop.entitlements \
             "ErrandDesktop.app"
 
+          codesign -dvv "ErrandDesktop.app"
+          codesign --verify --strict --verbose=2 "ErrandDesktop.app"
+
       - name: Create DMG
-        env:
-          DMG_SUFFIX: ${{ matrix.dmg_suffix }}
         run: |
           chmod +x scripts/create-dmg.sh
-          scripts/create-dmg.sh ErrandDesktop.app "ErrandDesktop-${DMG_SUFFIX}.dmg"
+          scripts/create-dmg.sh ErrandDesktop.app ErrandDesktop.dmg
 
       - name: Sign DMG
-        env:
-          DMG_SUFFIX: ${{ matrix.dmg_suffix }}
         run: |
           codesign --force --verify --verbose \
             --sign "Developer ID Application" \
-            "ErrandDesktop-${DMG_SUFFIX}.dmg"
+            ErrandDesktop.dmg
 
       - name: Notarize
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           TEAM_ID: ${{ secrets.TEAM_ID }}
-          DMG_SUFFIX: ${{ matrix.dmg_suffix }}
         run: |
-          xcrun notarytool submit "ErrandDesktop-${DMG_SUFFIX}.dmg" \
+          xcrun notarytool submit ErrandDesktop.dmg \
             --apple-id "$APPLE_ID" \
             --password "$APPLE_PASSWORD" \
             --team-id "$TEAM_ID" \
             --wait
 
-          xcrun stapler staple "ErrandDesktop-${DMG_SUFFIX}.dmg"
+          xcrun stapler staple ErrandDesktop.dmg
+
+      - name: Verify Gatekeeper acceptance
+        run: |
+          spctl --assess --type install --verbose=4 ErrandDesktop.dmg
+          spctl --assess --type execute --verbose=4 "ErrandDesktop.app"
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ErrandDesktop-${{ matrix.dmg_suffix }}.dmg
-          path: "ErrandDesktop-${{ matrix.dmg_suffix }}.dmg"
+          name: ErrandDesktop.dmg
+          path: ErrandDesktop.dmg
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v3
         with:
-          files: "ErrandDesktop-${{ matrix.dmg_suffix }}.dmg"
+          files: ErrandDesktop.dmg
           generate_release_notes: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ErrandDesktop is a native macOS menu bar app (Swift 6.2, macOS 26+/Tahoe, Apple silicon only) that runs the [Errand](https://github.com/errand-ai/errand-ai) stack locally using Apple's [Containerization](https://github.com/apple/swift-containerization) framework. It manages PostgreSQL, Valkey, Backend, and Worker as lightweight VM-based containers — no Docker required.
+ErrandDesktop is a native macOS menu bar app (Swift 6.2, macOS 15+/Sequoia, universal `arm64` + `x86_64`) that runs the [Errand](https://github.com/errand-ai/errand-ai) stack locally. It manages PostgreSQL, Valkey, Backend, and Worker as containers through one of two runtimes:
+
+- **Docker** — any supported Mac (Apple silicon or Intel, macOS 15+). Talks to any Docker-compatible socket: Docker Desktop, Colima, OrbStack, Rancher Desktop.
+- **Apple Containerization** — macOS 26 (Tahoe) on Apple silicon only. Lightweight VM-based containers, no Docker required.
+
+macOS 15 is the floor because the upstream `swift-containerization` package declares its own `.macOS("15")` minimum, and SwiftPM minimums apply at link time regardless of `@available` gating. The dependency is pinned to `"0.26.0"..<"0.27.0"` in `Package.swift` so a minor bump cannot silently raise that floor.
+
+### macOS 26 availability gating
+
+The app deploys to macOS 15, so every Apple Containerization symbol must be gated:
+
+- `AppleContainerRuntime` (the whole actor) is `@available(macOS 26, *)`.
+- Ext4 disk image creation lives in `Sources/ErrandDesktop/Storage/AppleStorageHelpers.swift` — a `@available(macOS 26, *)` extension on `StorageManager` — so `StorageManager` itself carries no `ContainerizationEXT4` dependency.
+- Every `as? AppleContainerRuntime` cast in `ContainerEngine`, and the construction site in `AppState`, is wrapped in `if #available(macOS 26, *)` / `guard #available(macOS 26, *)`.
+
+When adding code that touches `Containerization`, `ContainerizationOCI`, or `ContainerizationEXT4`, put it behind one of those gates — an ungated reference breaks the Sequoia build.
 
 ## Build & Run Commands
 
@@ -69,9 +84,18 @@ HTTP parsing is hand-rolled in `HTTPTypes.swift` (no external HTTP server depend
 - The app is a `MenuBarExtra` with `.window` style — no dock icon (`LSUIElement = true`).
 - Resources (menu bar icons) are in `Sources/ErrandDesktop/Resources/` and accessed via `Bundle.module`.
 
-## CI
+## CI & Distribution
 
-GitHub Actions (`.github/workflows/build.yml`): builds on macOS 15, runs tests, then for main/tags creates a signed+notarized DMG release.
+GitHub Actions (`.github/workflows/build.yml`) builds and tests, then for main/tags produces a signed+notarized release on an Apple silicon runner.
+
+- `scripts/build-universal.sh` builds the `arm64` and `x86_64` slices with identical flags and merges them with `lipo -create`. The `x86_64` slice is cross-compiled — no Intel runner is required.
+- The bundled `Info.plist` sets `LSMinimumSystemVersion` to `15.0`; the workflow fails the build if it does not.
+- **Naming contract**: each release publishes exactly one asset, named `ErrandDesktop.dmg` — no architecture or version suffix. The Homebrew cask resolves `releases/download/v<version>/ErrandDesktop.dmg`, so changing the filename breaks every install and upgrade.
+- Tags are `v<semver>` and must match the `CFBundleShortVersionString` baked into the bundle.
+
+**Homebrew is the canonical upgrade channel.** The cask lives in the separate public tap repo [`errand-ai/homebrew-errand`](https://github.com/errand-ai/homebrew-errand) at `Casks/errand-desktop.rb`; users install with `brew tap errand-ai/errand && brew install --cask errand-desktop` and upgrade with `brew upgrade --cask errand-desktop`. After cutting a release, the cask's `version` and `sha256` must be updated in that repo.
+
+The app does not self-update. `UpdateChecker` polls `errand-ai/errand-desktop` releases and posts a notification only.
 
 ## Serena (Code Intelligence)
 

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,15 @@ import PackageDescription
 let package = Package(
     name: "ErrandDesktop",
     platforms: [
-        .macOS(.v26)
+        .macOS(.v15)
     ],
     products: [
         .executable(name: "ErrandDesktop", targets: ["ErrandDesktop"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/containerization.git", from: "0.26.0"),
+        // Pinned to a tight range: the package declares its own `.macOS("15")` floor,
+        // and a future minor bump could silently raise our minimum deployment target.
+        .package(url: "https://github.com/apple/containerization.git", "0.26.0"..<"0.27.0"),
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -1,12 +1,60 @@
 # ErrandDesktop
 
-A native macOS menu bar app that runs the [Errand](https://github.com/errand-ai/errand-ai) stack locally using Apple's [Containerization](https://github.com/apple/swift-containerization) framework. Manages PostgreSQL, Valkey, Backend, and Worker as lightweight VM-based containers on Apple silicon — no Docker required.
+A native macOS menu bar app that runs the [Errand](https://github.com/errand-ai/errand-ai) stack locally. Manages PostgreSQL, Valkey, Backend, and Worker as containers via either Docker (any supported Mac) or Apple's [Containerization](https://github.com/apple/swift-containerization) framework (macOS 26 + Apple silicon, no Docker required).
+
+## Install
+
+```bash
+brew tap errand-ai/errand
+brew trust errand-ai/errand          # Homebrew 6+ only; see note below
+brew install --cask errand-desktop
+```
+
+These are one-time steps. After that, `brew upgrade --cask errand-desktop` keeps the
+app current.
+
+Homebrew 6 refuses to load casks from a non-official tap until you trust it — the
+`brew trust` line is what grants that. On Homebrew 5 and earlier the command does not
+exist and is not needed; skip it.
+
+If you would rather not use Homebrew, download `ErrandDesktop.dmg` from the
+[latest release](https://github.com/errand-ai/errand-desktop/releases/latest),
+open it, and drag `ErrandDesktop.app` into `/Applications`. The DMG is signed and
+notarized, so it launches without a Gatekeeper override.
+
+## Upgrading
+
+Homebrew is the canonical upgrade channel:
+
+```bash
+brew upgrade --cask errand-desktop
+```
+
+The app does not update itself. It checks GitHub Releases roughly once a day and
+posts a notification when a newer version exists — Homebrew users run the command
+above, manual installers click the notification to open the release page and
+replace `/Applications/ErrandDesktop.app` with the new DMG.
 
 ## Requirements
 
-- macOS 26+ (Tahoe)
-- Apple silicon (M1 or later)
-- Swift 6.1+
+A single universal (`arm64` + `x86_64`) build covers every supported Mac; there is
+nothing architecture-specific to choose at install time.
+
+| Hardware | macOS | Docker runtime | Apple Containerization |
+| --- | --- | --- | --- |
+| Apple silicon | 26+ (Tahoe) | Yes | Yes |
+| Apple silicon | 15 (Sequoia) | Yes | No — requires macOS 26 |
+| Intel | 15+ (Sequoia) | Yes | No — requires Apple silicon |
+| Any | 14 and earlier | Not supported | Not supported |
+
+macOS 15 (Sequoia) is the floor: the upstream `swift-containerization` package
+declares its own `.macOS("15")` minimum, and SwiftPM minimums apply at link time
+regardless of `@available` gating.
+
+Docker mode needs a Docker-compatible socket — Docker Desktop, Colima, OrbStack, or
+Rancher Desktop all work.
+
+Building from source additionally requires Swift 6.2+.
 
 ## Features
 
@@ -43,11 +91,17 @@ swift test
 
 ## Distribution
 
-Release builds are signed, notarized, and packaged as a DMG via CI:
+Every tagged release publishes exactly one asset — `ErrandDesktop.dmg` — containing
+a universal `.app`. The filename is a contract: the Homebrew cask in
+[`errand-ai/homebrew-errand`](https://github.com/errand-ai/homebrew-errand) resolves
+`releases/download/v<version>/ErrandDesktop.dmg`, so no architecture or version
+suffix may be added.
+
+CI builds, signs, notarizes, and publishes it. To reproduce locally:
 
 ```bash
-# Build release binary
-swift build -c release
+# Build both slices and merge them into one universal binary
+scripts/build-universal.sh .build/universal/ErrandDesktop
 
 # Create DMG (after building the app bundle)
 scripts/create-dmg.sh ErrandDesktop.app ErrandDesktop.dmg

--- a/Sources/ErrandDesktop/App/AppState.swift
+++ b/Sources/ErrandDesktop/App/AppState.swift
@@ -159,6 +159,14 @@ class AppState: ObservableObject {
                 runtime = DockerRuntime(socketPath: socketPath)
                 appendLog(service: "system", message: "Docker socket: \(socketPath)")
             case .appleContainerization:
+                // RuntimeDetector only reports this capability on macOS 26 + Apple Silicon,
+                // but the compiler still needs the availability guard here.
+                guard #available(macOS 26, *) else {
+                    let msg = "Apple Containerization requires macOS 26 on Apple Silicon."
+                    runtimeError = msg
+                    appendLog(service: "system", message: msg)
+                    return
+                }
                 runtime = AppleContainerRuntime()
             }
             try await containerEngine?.setRuntime(runtime, capability: chosen)

--- a/Sources/ErrandDesktop/App/UpdateChecker.swift
+++ b/Sources/ErrandDesktop/App/UpdateChecker.swift
@@ -16,8 +16,12 @@ class UpdateChecker: ObservableObject {
     }
 
     /// Repository path for the GitHub Releases API.
-    /// Update this to match your org/repo.
-    static let repoPath = "errand/errand-desktop"
+    static let repoPath = "errand-ai/errand-desktop"
+
+    /// The GitHub Releases endpoint polled by `checkForUpdate`.
+    static var latestReleaseURL: URL? {
+        URL(string: "https://api.github.com/repos/\(repoPath)/releases/latest")
+    }
 
     /// Starts periodic update checks — on launch and every 24 hours.
     func startPeriodicChecks() {
@@ -40,8 +44,7 @@ class UpdateChecker: ObservableObject {
 
     /// Checks the GitHub Releases API for a newer version.
     func checkForUpdate() async {
-        let urlString = "https://api.github.com/repos/\(Self.repoPath)/releases/latest"
-        guard let url = URL(string: urlString) else { return }
+        guard let url = Self.latestReleaseURL else { return }
 
         do {
             var request = URLRequest(url: url)
@@ -97,7 +100,10 @@ class UpdateChecker: ObservableObject {
 
         let content = UNMutableNotificationContent()
         content.title = "Update Available"
-        content.body = "ErrandDesktop \(version) is available. Click to download."
+        // Install-path agnostic: Brew users upgrade in place, manual installers click
+        // through to the release page (the click action below still opens it).
+        content.body = "ErrandDesktop \(version) is available. "
+            + "Run `brew upgrade --cask errand-desktop`, or visit the release page."
         content.sound = .default
 
         let request = UNNotificationRequest(

--- a/Sources/ErrandDesktop/Container/AppleContainerRuntime.swift
+++ b/Sources/ErrandDesktop/Container/AppleContainerRuntime.swift
@@ -31,6 +31,11 @@ private final class DebugWriter: Writer, @unchecked Sendable {
 
 /// Apple Containerization framework implementation of the ContainerRuntime protocol.
 /// Manages lightweight Linux VMs using Apple's native Containerization APIs.
+///
+/// Apple's Containerization framework requires macOS 26 (Tahoe) on Apple Silicon.
+/// The app itself deploys to macOS 15, so every use of this type must be guarded
+/// by `if #available(macOS 26, *)` (see `RuntimeDetector.isAppleContainerizationAvailable`).
+@available(macOS 26, *)
 actor AppleContainerRuntime: ContainerRuntime {
 
     /// The shared ContainerManager that owns the VM network and kernel.

--- a/Sources/ErrandDesktop/Container/ContainerEngine.swift
+++ b/Sources/ErrandDesktop/Container/ContainerEngine.swift
@@ -277,7 +277,7 @@ actor ContainerEngine {
         case .docker:
             hostGatewayIP = "host.docker.internal"
         case .appleContainerization:
-            if let appleRuntime = runtime as? AppleContainerRuntime {
+            if #available(macOS 26, *), let appleRuntime = runtime as? AppleContainerRuntime {
                 try await appleRuntime.ensureInitialized()
                 hostGatewayIP = await appleRuntime.hostGatewayIP
             }
@@ -406,7 +406,7 @@ actor ContainerEngine {
     /// Returns true if the container process for a service has exited unexpectedly.
     func hasExited(serviceId: String) async -> Bool {
         guard let containerId = serviceContainerMap[serviceId] else { return false }
-        if let appleRuntime = runtime as? AppleContainerRuntime {
+        if #available(macOS 26, *), let appleRuntime = runtime as? AppleContainerRuntime {
             return await appleRuntime.hasExited(id: containerId)
         }
         if let dockerRuntime = runtime as? DockerRuntime {
@@ -708,7 +708,8 @@ actor ContainerEngine {
 
     /// Waits for a container to exit and returns its exit code.
     private func waitForContainerExit(containerId: String, timeout: Int) async throws -> Int {
-        if let appleRuntime = runtime as? AppleContainerRuntime,
+        if #available(macOS 26, *),
+           let appleRuntime = runtime as? AppleContainerRuntime,
            let container = await appleRuntime.getContainer(id: containerId) {
             let status = try await container.wait()
             return Int(status.exitCode)
@@ -910,7 +911,8 @@ actor ContainerEngine {
     /// Monitors a task container for exit — uses Apple container.wait() when available,
     /// falls back to polling Docker inspect API.
     private func monitorTaskContainerExit(containerId: String) async {
-        if let appleRuntime = runtime as? AppleContainerRuntime,
+        if #available(macOS 26, *),
+           let appleRuntime = runtime as? AppleContainerRuntime,
            let container = await appleRuntime.getContainer(id: containerId) {
             do {
                 let exitStatus = try await container.wait()
@@ -1000,7 +1002,7 @@ actor ContainerEngine {
                     continuation.finish(throwing: error)
                 }
             }
-        } else if let appleRuntime = runtime as? AppleContainerRuntime {
+        } else if #available(macOS 26, *), let appleRuntime = runtime as? AppleContainerRuntime {
             Task {
                 do {
                     let appleStream = try await appleRuntime.containerLogs(id: id)
@@ -1333,6 +1335,7 @@ actor ContainerEngine {
                 // (chown failures) that occur with bind mounts on some systems.
                 return ["errand-postgres-data": "/var/lib/postgresql/data"]
             } else {
+                guard #available(macOS 26, *) else { return [:] }
                 let diskPath = (try? storageManager.ensureDataDisk(for: "postgres", sizeInMB: 1024)) ?? ""
                 return [diskPath: "/var/lib/postgresql/data"]
             }
@@ -1340,6 +1343,7 @@ actor ContainerEngine {
             if isDockerRuntime {
                 return ["errand-valkey-data": "/data"]
             } else {
+                guard #available(macOS 26, *) else { return [:] }
                 let diskPath = (try? storageManager.ensureDataDisk(for: "valkey", sizeInMB: 256)) ?? ""
                 return [diskPath: "/data"]
             }

--- a/Sources/ErrandDesktop/Storage/AppleStorageHelpers.swift
+++ b/Sources/ErrandDesktop/Storage/AppleStorageHelpers.swift
@@ -1,0 +1,39 @@
+import Foundation
+import ContainerizationEXT4
+import SystemPackage
+
+/// Ext4 disk image support for the Apple Containerization runtime.
+///
+/// Postgres and Valkey need full filesystem control (chown, chmod), which virtiofs
+/// shares cannot provide, so under Apple Containerization they are backed by ext4
+/// block devices instead. Docker uses named volumes and never reaches this code.
+///
+/// This lives apart from `StorageManager` so that `StorageManager` — which every
+/// runtime uses — carries no `ContainerizationEXT4` dependency and stays callable
+/// on macOS 15, where Apple Containerization is unavailable.
+@available(macOS 26, *)
+extension StorageManager {
+
+    /// Returns the path to a service's ext4 disk image, creating it if needed.
+    func ensureDataDisk(for serviceId: String, sizeInMB: Int) throws -> String {
+        let fm = FileManager.default
+        let disksDir = dataDir.appendingPathComponent("disks")
+        try fm.createDirectory(at: disksDir, withIntermediateDirectories: true)
+
+        let diskPath = disksDir.appendingPathComponent("\(serviceId).img")
+
+        if fm.fileExists(atPath: diskPath.path) {
+            print("[StorageManager] Using existing disk image: \(diskPath.path)")
+            return diskPath.path
+        }
+
+        print("[StorageManager] Creating \(sizeInMB)MB ext4 disk image for \(serviceId)...")
+        let sizeInBytes = UInt64(sizeInMB) * 1024 * 1024
+        let filePath = FilePath(diskPath.path)
+        let formatter = try EXT4.Formatter(filePath, minDiskSize: sizeInBytes)
+        try formatter.close()
+        print("[StorageManager] Disk image created: \(diskPath.path)")
+
+        return diskPath.path
+    }
+}

--- a/Sources/ErrandDesktop/Storage/StorageManager.swift
+++ b/Sources/ErrandDesktop/Storage/StorageManager.swift
@@ -1,6 +1,4 @@
 import Foundation
-import ContainerizationEXT4
-import SystemPackage
 
 /// Manages persistent storage in ~/Library/Application Support/ErrandDesktop/
 class StorageManager {
@@ -10,7 +8,8 @@ class StorageManager {
     private let appSupportDir: URL
 
     /// Data directory for container volume mounts.
-    private let dataDir: URL
+    /// Internal (not private) so `AppleStorageHelpers` can reach it.
+    let dataDir: URL
 
     /// Path to the persisted config.json file.
     private let configFileURL: URL
@@ -59,31 +58,6 @@ class StorageManager {
     /// Returns the host path for a service's data volume (virtiofs shares).
     func dataPath(for serviceId: String) -> String {
         dataDir.appendingPathComponent(serviceId).path
-    }
-
-    // MARK: - Ext4 Disk Images
-
-    /// Returns the path to a service's ext4 disk image, creating it if needed.
-    /// Used for services like postgres and valkey that need full filesystem control.
-    func ensureDataDisk(for serviceId: String, sizeInMB: Int) throws -> String {
-        let disksDir = dataDir.appendingPathComponent("disks")
-        try fm.createDirectory(at: disksDir, withIntermediateDirectories: true)
-
-        let diskPath = disksDir.appendingPathComponent("\(serviceId).img")
-
-        if fm.fileExists(atPath: diskPath.path) {
-            print("[StorageManager] Using existing disk image: \(diskPath.path)")
-            return diskPath.path
-        }
-
-        print("[StorageManager] Creating \(sizeInMB)MB ext4 disk image for \(serviceId)...")
-        let sizeInBytes = UInt64(sizeInMB) * 1024 * 1024
-        let filePath = FilePath(diskPath.path)
-        let formatter = try EXT4.Formatter(filePath, minDiskSize: sizeInBytes)
-        try formatter.close()
-        print("[StorageManager] Disk image created: \(diskPath.path)")
-
-        return diskPath.path
     }
 
     // MARK: - Config Persistence

--- a/Tests/ErrandDesktopTests/UpdateCheckerTests.swift
+++ b/Tests/ErrandDesktopTests/UpdateCheckerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ErrandDesktop
+
+// MARK: - GitHub Releases endpoint
+
+@MainActor
+final class UpdateCheckerTests: XCTestCase {
+
+    /// The repo path was previously `errand/errand-desktop`, which 404s silently and
+    /// meant no user ever saw an update notification. The cask's livecheck and the
+    /// in-app checker must both point at the same repository.
+    func testRepoPathTargetsErrandAIOrg() {
+        XCTAssertEqual(UpdateChecker.repoPath, "errand-ai/errand-desktop")
+    }
+
+    func testLatestReleaseURLTargetsErrandAIOrg() throws {
+        let url = try XCTUnwrap(UpdateChecker.latestReleaseURL)
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://api.github.com/repos/errand-ai/errand-desktop/releases/latest"
+        )
+        XCTAssertEqual(url.host, "api.github.com")
+        XCTAssertEqual(url.path, "/repos/errand-ai/errand-desktop/releases/latest")
+    }
+}

--- a/openspec/changes/homebrew-distribution/.openspec.yaml
+++ b/openspec/changes/homebrew-distribution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/homebrew-distribution/design.md
+++ b/openspec/changes/homebrew-distribution/design.md
@@ -1,0 +1,146 @@
+## Context
+
+ErrandDesktop today ships only as a hand-installed signed+notarized DMG with a hard requirement of macOS 26 (Tahoe) on Apple Silicon. The upstream constraint that drove that floor is Apple's `Containerization` framework, which requires macOS 26 + arm64. However, ErrandDesktop also implements a `DockerRuntime` backend that talks to any Docker-compatible socket (Docker Desktop, Colima, OrbStack, Rancher Desktop). The Docker backend has no architectural reason to require Tahoe or Apple Silicon — it's just been forced along by the SwiftPM deployment target.
+
+A quick audit confirmed the codebase isolates Apple Containerization cleanly:
+
+- Only `AppleContainerRuntime.swift` imports `Containerization` / `ContainerizationOCI`.
+- `StorageManager.swift` imports `ContainerizationEXT4` for `EXT4.Formatter`, used only by `ensureDataDisk(for:sizeInMB:)` (postgres + valkey ext4 images, only relevant on the Apple-Cont path).
+- `ContainerEngine` references `AppleContainerRuntime` only via `as?` casts at six sites; it does not import the framework directly.
+- No direct `Virtualization` / `VZ*` / `vmnet` symbols appear outside the upstream package.
+
+A trial `swift build -c release --arch x86_64` against the current source tree succeeded end-to-end, confirming `swift-containerization` itself compiles for Intel.
+
+The remaining hard constraint is upstream: `swift-containerization`'s own `Package.swift` declares `platforms: [.macOS("15")]`. SwiftPM minimums propagate transitively at link time, so importing the package — even guarded by `@available` — forces our minimum to macOS 15 (Sequoia). Sonoma (14) is therefore not reachable without forking or splitting the build.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Install on any supported Mac with `brew install --cask errand-desktop`, once the tap is registered and trusted (Homebrew 6+ requires `brew trust` for non-official taps).
+- The command works regardless of CPU architecture — user does not need to know whether they are on Apple Silicon or Intel.
+- Lowest practical macOS minimum: Sequoia (15), opening Intel Macs and pre-Tahoe Apple Silicon Macs to the Docker runtime path.
+- A single universal binary / DMG per release — no per-architecture artifacts that the user must choose between.
+- Brew is the canonical upgrade channel; `brew upgrade --cask errand-desktop` works for users who installed via Brew.
+- The in-app update notification continues to work for users who installed manually, and steers all users toward Brew when relevant.
+- Apple Containerization remains available with full functionality on macOS 26 + Apple Silicon.
+
+**Non-Goals:**
+
+- In-app self-updating (Sparkle, custom updater). The notification stays a flag/banner only.
+- Submission to the official `homebrew-cask` tap. Own tap (`errand-ai/homebrew-errand`) is the v1 distribution.
+- Pre-Sequoia (Sonoma 14, Ventura 13) support. Blocked by `swift-containerization` minimum.
+- Per-runtime DMG variants (e.g. a "lite" Docker-only build that omits swift-containerization entirely). Single fat binary is simpler and the size cost is acceptable.
+- Auto-detecting Brew installs to suppress the in-app banner. The banner stays universal; copy is updated to mention Brew.
+
+## Decisions
+
+### Decision 1: Lower SwiftPM deployment target to macOS 15 (Sequoia), not Sonoma
+
+`Package.swift` will change from `.macOS(.v26)` to `.macOS(.v15)`. Sonoma (14) was the user's initial preference but is unreachable because `swift-containerization` declares `platforms: [.macOS("15")]` and SwiftPM minimums are link-time, not gateable with `@available`.
+
+**Alternatives considered:**
+
+- **Sonoma (14) via dependency fork**: Would require maintaining a fork of `swift-containerization` with a lowered minimum. Rejected — high maintenance cost for a one-version audience gain.
+- **Conditional inclusion via SwiftPM traits or split products**: Possible with newer SwiftPM, but introduces a build matrix (Apple-Cont vs Docker-only), splitting the binary surface. Rejected for v1; revisit if Sonoma support becomes important.
+- **Stay at macOS 26**: Defeats the purpose of universal binary + Brew distribution. Rejected.
+
+### Decision 2: Apple Containerization gated by `@available(macOS 26, *)` at three layers
+
+The codebase already concentrates Apple-Cont specifics into a small surface area. We will:
+
+1. Annotate the entire `AppleContainerRuntime` type with `@available(macOS 26, *)`.
+2. Move ext4 disk image creation out of `StorageManager` and into `AppleContainerRuntime` (or a `@available(macOS 26, *)`-annotated extension thereof) so `StorageManager` no longer imports `ContainerizationEXT4`. The function `ensureDataDisk(for:sizeInMB:)` is only ever called from the Apple-Cont path (verified — `ContainerEngine` only invokes it inside `if let appleRuntime = runtime as? AppleContainerRuntime` blocks).
+3. Wrap each `as? AppleContainerRuntime` cast site in `ContainerEngine` with `if #available(macOS 26, *) { ... }` so the cast is statically valid on older OSes.
+
+Rationale: keeps the `@available` plumbing in three known files, no scattered guards, and keeps `StorageManager` callable from any code path.
+
+**Alternatives considered:**
+
+- **`#if canImport(Containerization)`**: SwiftPM dependencies are unconditionally importable when present, so this guard would never short-circuit. Wrong tool for the job.
+- **Leave ext4 disk creation in `StorageManager` and just gate the function**: Possible, but the file-level `import ContainerizationEXT4` still attempts to load on macOS 15. In practice the framework is weakly-linked and loads fine, but cleaner separation makes the boundary obvious to future readers.
+
+### Decision 3: Universal binary built in CI via two-arch slice + `lipo`
+
+The CI job will build two release slices (`--arch arm64` and `--arch x86_64`) and combine them into a single Mach-O binary using `lipo -create` before code-signing and notarization. Both `swift build --arch arm64 --arch x86_64` and the two-pass `lipo` approach are viable; the two-pass approach is preferred because it reuses the existing successful `--arch arm64` build path and isolates Intel-specific build failures to a discrete CI step.
+
+The resulting `ErrandDesktop.app` ships one universal Mach-O binary. `Info.plist`'s `LSMinimumSystemVersion` will be set to `15.0`.
+
+**Alternatives considered:**
+
+- **Single-pass `swift build --arch arm64 --arch x86_64`**: Cleaner, but couples the two slices into one build and obscures per-arch failures. Could be adopted later as a refinement.
+- **Per-arch DMGs**: Forces the user (or the cask) to know about architecture. Rejected — defeats the user-facing goal.
+
+### Decision 4: Distribution via own tap (`errand-ai/homebrew-errand`), not homebrew-cask
+
+A new public repo `errand-ai/homebrew-errand` will host `Casks/errand-desktop.rb`. Install command becomes:
+
+```
+brew tap errand-ai/errand
+brew trust errand-ai/errand      # Homebrew 6+ only
+brew install --cask errand-desktop
+```
+
+The `brew trust` step is not optional on Homebrew 6: `HOMEBREW_REQUIRE_TAP_TRUST` is
+the default, `brew tap` does not prompt, and loading the cask raises
+`Homebrew::UntrustedTapError` until the tap is trusted. On Homebrew 5 and earlier the
+command does not exist and the step is skipped.
+
+**Alternatives considered:**
+
+- **Submit to official `homebrew-cask`**: Eliminates both the `brew tap` and the `brew trust` steps, since official taps are exempt from the trust check. Rejected for v1 — homebrew-cask has notability/maturity expectations, a slower review cycle, and the project hasn't yet stabilised release cadence. Revisit once Brew install metrics show meaningful usage.
+- **No tap, distribute DMG only**: Status quo. Rejected — the whole point of this change.
+
+### Decision 5: Cask uses `depends_on macos: ">= :sequoia"` with no `arch` stanza
+
+Because the binary is universal, the cask does not need an `arch arm:..., intel:...` selector. `depends_on macos:` is sufficient to gate installs on macOS 14 and below, where Brew will refuse the install with a clear error.
+
+`livecheck` will track GitHub Releases (`https://github.com/errand-ai/errand-desktop/releases.atom`) so `brew upgrade --cask errand-desktop` works automatically on each tagged release.
+
+### Decision 6: UpdateChecker remains a flag/banner only; copy updated, repo path fixed
+
+`UpdateChecker.swift` is purely a polling notification system — no download, no relaunch logic. Two changes:
+
+1. Fix `repoPath` from `"errand/errand-desktop"` to `"errand-ai/errand-desktop"`. Currently silently 404s, so no users have ever seen an update notification.
+2. Change notification copy from *"Click to download"* to be install-path agnostic and mention Brew first: *"ErrandDesktop X.Y.Z is available. Run `brew upgrade --cask errand-desktop`, or visit the release page."* The `userInfo` URL on the notification still opens the GitHub release page when clicked, so the manual-install path is preserved.
+
+We deliberately do NOT detect whether the running app was installed via Brew. Detection would be brittle (running from `/Applications` looks identical for both paths) and the dual-action copy is fine for both audiences.
+
+### Decision 7: GitHub Release naming convention is a contract
+
+The cask's `url` stanza will reference a stable release-asset path:
+
+```
+https://github.com/errand-ai/errand-desktop/releases/download/v#{version}/ErrandDesktop.dmg
+```
+
+The CI release pipeline must produce exactly this filename (no architecture suffix, no version suffix in the filename) for every release. This becomes a release-pipeline requirement codified in the new `release-pipeline` capability spec.
+
+## Risks / Trade-offs
+
+- **[Risk] `swift-containerization` may add macOS 26-only API in a future minor release** that is unconditionally referenced from a public symbol, which would cause `AppleContainerRuntime` to fail to compile on Sequoia even with `@available` annotations. → Mitigation: pin the dependency version in `Package.swift` and run CI on a Sequoia runner so any regression is caught at PR time, not at release time.
+- **[Trade-off] Universal binary is ~2× the size of a single-arch binary.** Acceptable: the ErrandDesktop app binary is small relative to the container images it pulls. Disk cost on user machines is negligible.
+- **[Risk] `lipo`-merged slices can have subtle linker-flag differences** if the two `swift build` invocations don't match exactly. → Mitigation: factor the build into a CI helper that runs both slices with identical environment and flags, only varying `--arch`.
+- **[Risk] Intel Macs running Sequoia have a tiny user base relative to Apple Silicon.** → Mitigation: this is fine — they're a bonus audience, not the primary target. The change still pays off for pre-Tahoe Apple Silicon users, who are likely the bulk of the new audience.
+- **[Trade-off] Own tap requires users to run `brew tap` and, on Homebrew 6+, `brew trust` first.** Three commands instead of one, and `brew trust` asks the user to accept third-party cask code — a real friction point and an argument for eventually moving to `homebrew-cask`. → Mitigation: both READMEs present tap+trust+install as a single copy-pasteable block and explain what the trust step grants; once done, future installs and upgrades are one command.
+- **[Risk] Brew upgrade and in-app banner could double-notify** users who have both running. → Acceptable: the banner is once per launch + once per 24h, the Brew notification is on `brew upgrade` invocation. They don't overlap meaningfully.
+- **[Risk] Existing macOS 26 + Apple Silicon users may worry the change degrades them.** → Mitigation: their experience is unchanged. Apple Containerization is still offered, still preferred where appropriate, still has full functionality. The change is purely additive for them.
+- **[Risk] CI runner availability for x86_64 builds.** Apple is phasing out Intel macOS runners. → Mitigation: build x86_64 slice via cross-compilation on an arm64 runner (`swift build --arch x86_64` works fine on arm64 hosts, as confirmed locally). No Intel runner needed.
+
+## Migration Plan
+
+1. Land Sequoia-target + `@available` gating in a single PR. CI builds and signs as today, but for the new minimum. No release cut yet.
+2. Land universal-binary CI changes in a second PR. Manually verify on an Intel + Sequoia machine and an Apple Silicon + Sequoia machine that the resulting `.app` launches and Docker runtime is selectable. Verify Apple Silicon + Tahoe still offers both runtimes.
+3. Cut a tagged release with the universal DMG.
+4. Create the `errand-ai/homebrew-errand` repo, add `Casks/errand-desktop.rb` pointing at the new release. Manually `brew install --cask` from the tap on a fresh Mac to verify install/launch.
+5. Update `errand-desktop/README.md` and `CLAUDE.md` with the new install/upgrade story. Land `UpdateChecker.swift` copy + repo path fixes in the same PR.
+6. Announce.
+
+**Rollback:** If a release is broken, the cask's `livecheck` will pick up the next tag — there's no rollback unique to Brew distribution. For a critical regression, retag the previous release as latest (or yank the bad tag and re-cut). The in-app banner will continue to show whatever GitHub Releases reports as latest.
+
+## Open Questions
+
+- **Where does the codesigning identity / notarization API key live for the new release pipeline?** Existing CI already does this; we just need to confirm the workflow secrets are available to the universal-build step.
+- **Should the tap repo also publish a `.json` or stable redirect for the cask version**, so the cask can use `livecheck do url ...` cleanly without needing the GitHub Atom feed? Probably not for v1 — Atom feed works.
+- **Does the `make run` workflow need updates** for the new minimum (it currently copies to `/var/tmp` for vmnet to work)? On Sequoia + Docker mode, `/var/tmp` placement is unnecessary; the Makefile may be simplified or left as-is for backward compat.
+- **Should `make` gain a `make brew-test` target** that builds + signs + drops a local DMG into a fixture cask for end-to-end verification before tagging? Nice-to-have, not blocking.

--- a/openspec/changes/homebrew-distribution/proposal.md
+++ b/openspec/changes/homebrew-distribution/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+ErrandDesktop is currently distributed only as a hand-installed signed+notarized DMG that requires macOS 26 (Tahoe) and Apple Silicon, even though the Docker runtime backend is hardware- and OS-agnostic in principle. This blocks Intel Mac users and pre-Tahoe Apple Silicon users from installing the app at all, and leaves macOS users without a single-command install path. Distributing via Homebrew (`brew install --cask errand-desktop`) plus a universal binary that lowers the minimum to macOS 15 (Sequoia) opens the app to the full audience that the Docker runtime already supports, with one canonical install and upgrade channel.
+
+## What Changes
+
+- Lower the SwiftPM deployment target from `.macOS(.v26)` to `.macOS(.v15)` (Sequoia). Sonoma (14) is not viable because the upstream `swift-containerization` package itself declares `.macOS("15")`.
+- Gate all Apple Containerization code paths behind `@available(macOS 26, *)` and `if #available(macOS 26, *)`:
+  - `AppleContainerRuntime` (whole type)
+  - `StorageManager.ensureDataDisk` and the `ContainerizationEXT4` use it depends on (refactor permitting)
+  - The six `as? AppleContainerRuntime` cast sites in `ContainerEngine`
+- Build a universal (`arm64` + `x86_64`) binary in CI by either passing `--arch arm64 --arch x86_64` to `swift build`, or building each slice and joining with `lipo -create`.
+- Update `.github/workflows/build.yml` to produce a single signed+notarized `ErrandDesktop.dmg` per release (no per-arch artifact split). Update `Info.plist`'s `LSMinimumSystemVersion` to `15.0`.
+- Create a new public Homebrew tap repository `errand-ai/homebrew-errand` containing `Casks/errand-desktop.rb`. The cask uses `depends_on macos: ">= :sequoia"`, includes a `livecheck` stanza pointing at GitHub Releases, and downloads the single universal DMG.
+- Update `UpdateChecker.swift`:
+  - Fix `repoPath` from `"errand/errand-desktop"` to `"errand-ai/errand-desktop"` (currently silently 404s).
+  - Change the in-app notification copy to be install-path agnostic, mentioning `brew upgrade --cask errand-desktop` alongside the GitHub releases page link.
+- Document the install sequence (`brew tap errand-ai/errand`, then `brew trust errand-ai/errand`, then `brew install --cask errand-desktop`) and the upgrade story (`brew upgrade --cask errand-desktop`) in the project README. The `brew trust` step is required on Homebrew 6+, which refuses to load casks from non-official taps until they are trusted, and `brew tap` does not prompt for it. Brew is the supported upgrade channel; the app does not self-update.
+
+## Capabilities
+
+### New Capabilities
+
+- `homebrew-distribution`: Defines the Homebrew tap and cask contract — naming, source DMG URL convention, supported macOS floor, architecture support claim, livecheck behaviour, and the relationship between GitHub Releases and `brew upgrade`.
+- `release-pipeline`: Defines the CI build/sign/notarize/release contract — universal binary requirement, single-DMG-per-release rule, `Info.plist` minimum version, GitHub Release naming convention that the cask depends on.
+
+### Modified Capabilities
+
+- `runtime-selection`: The minimum supported OS shifts from macOS 26 to macOS 15. The behaviour rule "Apple Containerization is only offered on macOS 26+ Apple Silicon" is unchanged in spirit but must now be enforced on systems where the app itself is allowed to run (previously a no-op since the app couldn't launch at all on those systems).
+- `container-runtime-abstraction`: Implementation must compile and run on macOS 15+, with Apple Containerization symbols guarded by `@available(macOS 26, *)`. The protocol surface is unchanged; the requirement that adds is "the abstraction must remain usable when the Apple Containerization implementation is unavailable at runtime."
+
+## Impact
+
+- **Source code**: `Package.swift`, `Sources/ErrandDesktop/Container/AppleContainerRuntime.swift`, `Sources/ErrandDesktop/Container/ContainerEngine.swift`, `Sources/ErrandDesktop/Storage/StorageManager.swift`, `Sources/ErrandDesktop/App/UpdateChecker.swift`.
+- **Build & release**: `.github/workflows/build.yml`, `ErrandDesktop.entitlements` (no change expected, just verification), `Info.plist` (`LSMinimumSystemVersion`), `Makefile` (verify `make run` still works on Sequoia).
+- **External**: New repository `errand-ai/homebrew-errand` containing `Casks/errand-desktop.rb` and a README. GitHub Releases naming convention becomes a contract that the cask consumes.
+- **Documentation**: Project `README.md` updated with Homebrew install/upgrade instructions and the revised macOS support matrix. `CLAUDE.md` updated to reflect the new minimum macOS, dual-runtime hardware support, and Brew as the upgrade channel.
+- **Users**: Existing users who installed via DMG will continue to work; on next launch, the in-app update notification will steer them toward `brew upgrade --cask errand-desktop`. Intel + Sequoia users gain the ability to install the app for the first time, in Docker-runtime-only mode.
+- **Out of scope**: In-app self-update / Sparkle integration; submission to the official `homebrew-cask` tap (own tap only for v1); pre-Sequoia (Sonoma 14 or earlier) support.

--- a/openspec/changes/homebrew-distribution/specs/homebrew-distribution/spec.md
+++ b/openspec/changes/homebrew-distribution/specs/homebrew-distribution/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Homebrew tap repository
+
+The project SHALL maintain a public Homebrew tap repository at `errand-ai/homebrew-errand` that hosts the cask definition for ErrandDesktop.
+
+#### Scenario: Tap is publicly reachable
+- **WHEN** a user runs `brew tap errand-ai/errand`
+- **THEN** Homebrew clones `https://github.com/errand-ai/homebrew-errand` successfully and registers the tap
+
+#### Scenario: Tap contains the errand-desktop cask
+- **WHEN** the tap is registered
+- **THEN** the file `Casks/errand-desktop.rb` exists in the tap repository
+- **AND** `brew search errand-desktop` lists it
+- **AND** loading the cask still requires the tap to be trusted on Homebrew 6+
+
+### Requirement: Tap trust is a documented prerequisite
+
+Homebrew 6 refuses to load casks from non-official taps until the tap is trusted: `HOMEBREW_REQUIRE_TAP_TRUST` is the default, and `brew tap` does not prompt for trust. The documented install sequence SHALL therefore include `brew trust errand-ai/errand` between tapping and installing, annotated as applying to Homebrew 6 and later only — on Homebrew 5 and earlier the command does not exist and is not needed.
+
+#### Scenario: Untrusted tap on Homebrew 6
+- **WHEN** a user on Homebrew 6 or later registers the tap and runs `brew install --cask errand-desktop` without having trusted the tap
+- **THEN** Homebrew refuses with an untrusted-tap error that names `brew trust errand-ai/errand`
+- **AND** no files are written to `/Applications`
+
+#### Scenario: Tap trusted on Homebrew 6
+- **WHEN** the user runs `brew trust errand-ai/errand` and then `brew install --cask errand-desktop`
+- **THEN** the install proceeds normally
+
+#### Scenario: Documented install sequence
+- **WHEN** a user follows the Install section of either the project README or the tap README
+- **THEN** the documented sequence is `brew tap errand-ai/errand`, then `brew trust errand-ai/errand`, then `brew install --cask errand-desktop`
+- **AND** the `brew trust` step is annotated as Homebrew 6+ only
+
+### Requirement: Architecture-agnostic install
+
+Once the tap is registered and trusted, the system SHALL install on any supported Mac via a single `brew install --cask errand-desktop`, without the user needing to know their CPU architecture or supply architecture-specific arguments.
+
+#### Scenario: Install on Apple Silicon
+- **WHEN** a user on Apple Silicon runs `brew install --cask errand-desktop` against a registered and trusted tap
+- **THEN** Homebrew downloads the universal DMG, mounts it, and installs `ErrandDesktop.app` into `/Applications`
+- **AND** no `--arch` or similar flag is required from the user
+
+#### Scenario: Install on Intel
+- **WHEN** a user on Intel macOS Sequoia or later runs `brew install --cask errand-desktop` against a registered and trusted tap
+- **THEN** Homebrew downloads the same universal DMG and installs `ErrandDesktop.app` into `/Applications`
+- **AND** no `--arch` or similar flag is required from the user
+
+### Requirement: Minimum macOS gate enforced by cask
+
+The cask SHALL refuse to install on unsupported macOS versions via a `depends_on macos:` declaration so that the user sees a clear refusal rather than a silent install of an unsupported binary.
+
+#### Scenario: Install on macOS Sonoma (14)
+- **WHEN** a user on macOS 14 runs `brew install --cask errand-desktop`
+- **THEN** Homebrew refuses the install with a message indicating macOS Sequoia or later is required
+- **AND** no files are written to `/Applications`
+
+#### Scenario: Install on macOS Sequoia (15)
+- **WHEN** a user on macOS 15 runs `brew install --cask errand-desktop`
+- **THEN** the install proceeds normally
+
+### Requirement: Brew is the supported upgrade channel
+
+The cask SHALL be configured so that `brew upgrade --cask errand-desktop` retrieves new versions automatically when GitHub Releases publishes a new tag.
+
+#### Scenario: New version available
+- **WHEN** a new version is published to GitHub Releases for `errand-ai/errand-desktop`
+- **AND** the user runs `brew upgrade --cask errand-desktop`
+- **THEN** Homebrew detects the new version via livecheck and replaces the installed app with the new release
+
+#### Scenario: Already up to date
+- **WHEN** the user runs `brew upgrade --cask errand-desktop` and the installed version matches the latest GitHub Release
+- **THEN** Homebrew reports the cask is already up to date
+
+### Requirement: In-app update notification mentions Brew
+
+The in-app update notification posted by `UpdateChecker` SHALL be install-path agnostic and mention `brew upgrade --cask errand-desktop` as a primary upgrade option, while still preserving the option to download from GitHub Releases.
+
+#### Scenario: New version detected by UpdateChecker
+- **WHEN** `UpdateChecker` finds that GitHub Releases reports a newer version than the running app
+- **THEN** the macOS notification body mentions both `brew upgrade --cask errand-desktop` and the GitHub release page
+- **AND** clicking the notification still opens the GitHub release page in the default browser
+
+#### Scenario: UpdateChecker queries the correct repository
+- **WHEN** `UpdateChecker` polls GitHub Releases
+- **THEN** it queries `https://api.github.com/repos/errand-ai/errand-desktop/releases/latest` (not `errand/errand-desktop`)
+
+### Requirement: Apple Containerization remains available where supported
+
+Distributing via Homebrew SHALL NOT remove or degrade the Apple Containerization runtime on systems that support it (macOS 26 + Apple Silicon).
+
+#### Scenario: Tahoe + Apple Silicon after Brew install
+- **WHEN** a user on macOS 26 + Apple Silicon installs the cask and launches the app
+- **THEN** both Docker and Apple Containerization runtimes are offered in the runtime selector
+- **AND** Apple Containerization functions identically to the pre-Brew DMG install

--- a/openspec/changes/homebrew-distribution/specs/release-pipeline/spec.md
+++ b/openspec/changes/homebrew-distribution/specs/release-pipeline/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Universal binary in release artifacts
+
+Each release SHALL ship a universal Mach-O binary containing both `arm64` and `x86_64` slices in a single `ErrandDesktop.app`. The build pipeline SHALL produce both slices and combine them via `lipo -create` (or the equivalent multi-arch `swift build` flags) before code-signing.
+
+#### Scenario: Inspect the released app binary
+- **WHEN** the released `ErrandDesktop.app/Contents/MacOS/ErrandDesktop` is inspected with `lipo -info`
+- **THEN** the output reports two architectures: `x86_64 arm64`
+
+#### Scenario: Both slices are functional
+- **WHEN** the released app is launched on Intel macOS Sequoia
+- **THEN** the app launches without architecture-related errors and the Docker runtime is selectable
+
+#### Scenario: Apple Silicon slice retains full functionality
+- **WHEN** the released app is launched on Apple Silicon macOS Tahoe
+- **THEN** the app launches and Apple Containerization is selectable alongside Docker
+
+### Requirement: Single DMG per release
+
+Each tagged GitHub Release SHALL publish exactly one DMG asset, named `ErrandDesktop.dmg`, containing the universal `.app`. The pipeline SHALL NOT publish per-architecture DMGs (no `-arm64` / `-x86_64` suffixes).
+
+#### Scenario: Release assets list
+- **WHEN** a release is tagged and published
+- **THEN** the release's downloadable assets include exactly one `.dmg` file
+- **AND** that file is named `ErrandDesktop.dmg`
+
+#### Scenario: Cask URL stability
+- **WHEN** the cask references `https://github.com/errand-ai/errand-desktop/releases/download/v#{version}/ErrandDesktop.dmg`
+- **THEN** the URL resolves successfully for every published release of the corresponding version
+
+### Requirement: Minimum system version declared in Info.plist
+
+The bundled `Info.plist` SHALL declare `LSMinimumSystemVersion` of `15.0` so that macOS itself refuses to launch the app on Sonoma or earlier.
+
+#### Scenario: Info.plist value
+- **WHEN** the released `ErrandDesktop.app/Contents/Info.plist` is inspected
+- **THEN** the `LSMinimumSystemVersion` key has the value `15.0`
+
+#### Scenario: Launch on Sonoma
+- **WHEN** the released app is copied to `/Applications` on macOS 14
+- **AND** the user double-clicks it
+- **THEN** macOS shows a system error stating the app requires a newer version of macOS, and the app does not launch
+
+### Requirement: Code signed and notarized
+
+The released DMG and the embedded `.app` SHALL be signed with the project's Developer ID certificate and notarized by Apple before publication.
+
+#### Scenario: Notarization status of DMG
+- **WHEN** the release DMG is checked with `spctl --assess --type install`
+- **THEN** the assessment passes (the DMG is accepted by Gatekeeper)
+
+#### Scenario: Notarization status of app
+- **WHEN** the embedded `.app` is checked with `spctl --assess --type execute`
+- **THEN** the assessment passes (the app is accepted by Gatekeeper)
+
+#### Scenario: First-launch on a clean Mac
+- **WHEN** a user installs the cask on a Mac that has never seen the app before
+- **AND** launches it from `/Applications`
+- **THEN** the app opens without prompting the user to override Gatekeeper
+
+### Requirement: GitHub Release naming convention
+
+Each release SHALL be tagged in the form `v<semver>` (e.g. `v1.2.3`), matching the version string embedded in `Info.plist`'s `CFBundleShortVersionString`. This convention is a contract consumed by the cask's `version`, `url`, and `livecheck` stanzas.
+
+#### Scenario: Tag format
+- **WHEN** a release is published
+- **THEN** the git tag has the prefix `v` followed by a semver version (e.g. `v1.2.3`)
+
+#### Scenario: Version consistency
+- **WHEN** a release is published with tag `v1.2.3`
+- **THEN** `ErrandDesktop.app/Contents/Info.plist` contains `CFBundleShortVersionString = 1.2.3`
+
+### Requirement: x86_64 slice may be cross-compiled from arm64 hosts
+
+The build pipeline SHALL be permitted to produce the `x86_64` slice on an Apple Silicon CI runner (cross-compilation), so that the project does not depend on Apple-provided Intel macOS runners.
+
+#### Scenario: Cross-compiled x86_64 slice
+- **WHEN** CI runs on a `macos-15-arm64` (or equivalent Apple Silicon) runner
+- **THEN** `swift build -c release --arch x86_64` succeeds without an Intel host
+- **AND** the resulting slice is functional when merged into the universal binary

--- a/openspec/changes/homebrew-distribution/specs/runtime-selection/spec.md
+++ b/openspec/changes/homebrew-distribution/specs/runtime-selection/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Runtime auto-detection
+The system SHALL detect available container runtimes on startup based on macOS version, CPU architecture, and installed software. The minimum macOS version on which the app itself launches is Sequoia (15); auto-detection runs on every supported host.
+
+#### Scenario: macOS 26 + Apple Silicon with Docker installed
+- **WHEN** the app starts on macOS 26 with Apple Silicon and Docker is installed
+- **THEN** both Docker and Apple Containerization are reported as available
+- **THEN** Docker is the default selection
+
+#### Scenario: macOS 26 + Apple Silicon without Docker
+- **WHEN** the app starts on macOS 26 with Apple Silicon but Docker is not installed
+- **THEN** only Apple Containerization is reported as available
+- **THEN** Apple Containerization is auto-selected
+
+#### Scenario: Older macOS or Intel with Docker installed
+- **WHEN** the app starts on macOS 15–25 or on Intel hardware, and Docker is installed
+- **THEN** only Docker is reported as available
+- **THEN** Docker is auto-selected
+
+#### Scenario: Sequoia on Apple Silicon with Docker installed
+- **WHEN** the app starts on macOS 15 (Sequoia) with Apple Silicon and Docker is installed
+- **THEN** only Docker is reported as available (Apple Containerization is hidden because it requires macOS 26)
+- **THEN** Docker is auto-selected
+
+#### Scenario: Sequoia or later on Intel with Docker installed
+- **WHEN** the app starts on macOS 15+ with Intel hardware and Docker is installed
+- **THEN** only Docker is reported as available (Apple Containerization is hidden because it requires Apple Silicon)
+- **THEN** Docker is auto-selected
+
+#### Scenario: No runtime available
+- **WHEN** the app starts and neither Docker nor Apple Containerization is available
+- **THEN** the app displays an error with instructions to install Docker Desktop

--- a/openspec/changes/homebrew-distribution/tasks.md
+++ b/openspec/changes/homebrew-distribution/tasks.md
@@ -1,0 +1,46 @@
+## 1. Lower deployment target and gate Apple Containerization
+
+- [x] 1.1 Change `Package.swift` platform from `.macOS(.v26)` to `.macOS(.v15)`. Pin the `swift-containerization` dependency to its current version (`from: "0.26.0"` → exact `.exact("0.26.0")` or a tight upper bound) so future minor bumps cannot silently raise our floor.
+- [x] 1.2 Annotate the entire `AppleContainerRuntime` type in `Sources/ErrandDesktop/Container/AppleContainerRuntime.swift` with `@available(macOS 26, *)`.
+- [x] 1.3 Move `ensureDataDisk(for:sizeInMB:)` and the `import ContainerizationEXT4` out of `Sources/ErrandDesktop/Storage/StorageManager.swift` and into an `@available(macOS 26, *)` extension on `AppleContainerRuntime` (or a new `AppleStorageHelpers.swift`). Update `ContainerEngine.swift` call sites accordingly.
+- [x] 1.4 In `Sources/ErrandDesktop/Container/ContainerEngine.swift`, wrap each of the six `as? AppleContainerRuntime` cast sites in `if #available(macOS 26, *) { ... }` blocks. Verify call sites by searching for `AppleContainerRuntime` references.
+- [x] 1.5 Run `swift build -c release` on macOS Sequoia (15) to confirm the project compiles end-to-end with the lower target. Resolve any new `@available` warnings/errors from SwiftUI or system frameworks revealed by the lower target.
+- [x] 1.6 Run `swift build -c release --arch x86_64` to confirm the cross-compiled Intel slice still builds.
+- [x] 1.7 Run `swift test` to confirm the existing test suite passes against the new minimum.
+
+## 2. Universal binary build pipeline
+
+- [x] 2.1 Add a CI script (or inline workflow step) that builds the `arm64` and `x86_64` slices separately with identical environment and flags, then merges them via `lipo -create -output ErrandDesktop ErrandDesktop-arm64 ErrandDesktop-x86_64`. Verify the merged binary with `lipo -info`.
+- [x] 2.2 Update `.github/workflows/build.yml` to run the universal build on a `macos-15` (or later Apple Silicon) runner. Confirm Xcode toolchain on the runner can target macOS 15.
+- [x] 2.3 Update `Info.plist` to set `LSMinimumSystemVersion` to `15.0`. Verify the bundled `Info.plist` in the built `.app` reflects this.
+- [x] 2.4 Update the codesign step to sign the universal binary in place, then sign the `.app` wrapper. Verify with `codesign -dvv ErrandDesktop.app`.
+- [x] 2.5 Update the notarization step to submit the universal DMG. Verify with `spctl --assess --type install` and `spctl --assess --type execute` on the embedded app.
+- [x] 2.6 Ensure the release artifact is named exactly `ErrandDesktop.dmg` (no architecture suffix, no version suffix) so the cask URL pattern resolves.
+- [ ] 2.7 Manual smoke test: launch the universal DMG's `.app` from `/Applications` on (a) Apple Silicon + Tahoe, (b) Apple Silicon + Sequoia, (c) Intel + Sequoia. Confirm runtime selection presents the expected options on each.
+
+## 3. UpdateChecker fixes
+
+- [x] 3.1 Fix `repoPath` in `Sources/ErrandDesktop/App/UpdateChecker.swift` from `"errand/errand-desktop"` to `"errand-ai/errand-desktop"`.
+- [x] 3.2 Update the notification body in `postUpdateNotification` to read along the lines of: *"ErrandDesktop X.Y.Z is available. Run `brew upgrade --cask errand-desktop` or visit the release page."* Keep the existing click action that opens the release page in the default browser.
+- [x] 3.3 Add or update a unit test that asserts the GitHub Releases URL constructed by `checkForUpdate` targets `errand-ai/errand-desktop`.
+
+## 4. Homebrew tap repository
+
+- [ ] 4.1 Create the public repository `errand-ai/homebrew-errand` on GitHub. Add a top-level `README.md` with the install/upgrade instructions.
+- [ ] 4.2 Create `Casks/errand-desktop.rb` with `version`, `sha256`, `url` (pointing at `https://github.com/errand-ai/errand-desktop/releases/download/v#{version}/ErrandDesktop.dmg`), `name`, `desc`, `homepage`, `depends_on macos: ">= :sequoia"`, `app "ErrandDesktop.app"`, and a `livecheck` block targeting GitHub Releases.
+- [ ] 4.3 Validate the cask locally with `brew style --fix Casks/errand-desktop.rb` and `brew audit --cask --new errand-desktop` (or equivalent) before pushing.
+- [ ] 4.4 End-to-end install verification: on a Mac that has never installed ErrandDesktop, run `brew tap errand-ai/errand && brew install --cask errand-desktop`, confirm `/Applications/ErrandDesktop.app` is present, and launch the app.
+- [ ] 4.5 End-to-end upgrade verification: tag a patch release, confirm `brew upgrade --cask errand-desktop` picks up the new version on a previously-installed machine.
+
+## 5. Documentation
+
+- [x] 5.1 Update `README.md` in the errand-desktop repo with a "Install" section showing the Brew tap+install commands and the manual DMG fallback. Document the supported macOS / hardware matrix (Sequoia+ for Docker mode, Tahoe + Apple Silicon for Apple Containerization mode).
+- [x] 5.2 Update `README.md` with a "Upgrading" section explaining that Brew is the canonical upgrade channel.
+- [x] 5.3 Update `CLAUDE.md` to reflect the new minimum macOS, dual-runtime hardware support (Apple Silicon + Intel), Brew as the upgrade channel, and the `ErrandDesktop.dmg` naming contract.
+- [ ] 5.4 Update the homebrew tap repo's `README.md` with usage notes, link back to errand-desktop, and a brief "Why this tap exists" paragraph.
+
+## 6. Release and announcement
+
+- [ ] 6.1 Cut the first release that meets all the new requirements: universal binary, `LSMinimumSystemVersion 15.0`, `ErrandDesktop.dmg` naming, signed and notarized.
+- [ ] 6.2 Update the cask in `errand-ai/homebrew-errand` to point at this release's tag and SHA. Push the cask update.
+- [ ] 6.3 Announce the new install path (in the project README, release notes, and any user-facing channels). Note that existing users will see the in-app banner directing them to `brew upgrade` after the next release.

--- a/openspec/specs/runtime-selection/spec.md
+++ b/openspec/specs/runtime-selection/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Runtime auto-detection
 The system SHALL detect available container runtimes on startup based on macOS version, CPU architecture, and installed software.

--- a/scripts/build-universal.sh
+++ b/scripts/build-universal.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Builds the arm64 and x86_64 release slices with identical flags and merges them
+# into a single universal Mach-O binary.
+#
+# Both slices must come from the same source tree and the same environment — only
+# `--arch` varies — so that `lipo` cannot paper over a linker-flag mismatch.
+#
+# Usage: scripts/build-universal.sh [output-path]
+#   output-path defaults to .build/universal/ErrandDesktop
+set -euo pipefail
+
+OUTPUT="${1:-.build/universal/ErrandDesktop}"
+CONFIGURATION="release"
+
+build_slice() {
+  local arch="$1"
+  echo "==> Building ${arch} slice"
+  swift build -c "${CONFIGURATION}" --arch "${arch}"
+}
+
+build_slice arm64
+build_slice x86_64
+
+ARM64_BIN=".build/arm64-apple-macosx/${CONFIGURATION}/ErrandDesktop"
+X86_64_BIN=".build/x86_64-apple-macosx/${CONFIGURATION}/ErrandDesktop"
+
+for bin in "${ARM64_BIN}" "${X86_64_BIN}"; do
+  if [[ ! -f "${bin}" ]]; then
+    echo "error: expected slice not found at ${bin}" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$(dirname "${OUTPUT}")"
+echo "==> Merging slices into ${OUTPUT}"
+lipo -create -output "${OUTPUT}" "${ARM64_BIN}" "${X86_64_BIN}"
+
+echo "==> lipo -info"
+lipo -info "${OUTPUT}"
+
+# Fail loudly if either slice is missing from the merged binary.
+ARCHS="$(lipo -archs "${OUTPUT}")"
+for expected in arm64 x86_64; do
+  if [[ " ${ARCHS} " != *" ${expected} "* ]]; then
+    echo "error: universal binary is missing the ${expected} slice (got: ${ARCHS})" >&2
+    exit 1
+  fi
+done
+
+echo "==> Universal binary ready: ${OUTPUT}"


### PR DESCRIPTION
Implements the `homebrew-distribution` OpenSpec change (§1–§3, §5).

## What this does

Lowers the deployment target from macOS 26 to **macOS 15 (Sequoia)** and ships a single **universal `arm64` + `x86_64` DMG**, opening the app to Intel Macs and pre-Tahoe Apple Silicon in Docker-runtime mode. Apple Containerization is unchanged on macOS 26 + Apple Silicon.

macOS 15 is the floor because `swift-containerization` declares its own `.macOS("15")` minimum and SwiftPM minimums apply at link time regardless of `@available` gating. The dependency is pinned to `"0.26.0"..<"0.27.0"` so a minor bump cannot silently raise it.

## Availability gating

Everything Apple-Containerization is behind `@available(macOS 26, *)`:

- the whole `AppleContainerRuntime` actor
- all five `as? AppleContainerRuntime` casts in `ContainerEngine`, plus both `ensureDataDisk` call sites
- the construction site in `AppState`
- ext4 disk creation, which moves out of `StorageManager` into a new gated `Storage/AppleStorageHelpers.swift` — so `StorageManager` no longer imports `ContainerizationEXT4`

## Release pipeline

The per-arch release matrix collapses into one universal job. `scripts/build-universal.sh` builds both slices with identical flags (only `--arch` varies) and merges them with `lipo`, failing loudly if a slice is missing. The workflow then asserts `LSMinimumSystemVersion 15.0` and both slices before signing, signs the binary before the app wrapper, and checks `spctl` acceptance after notarization.

**Naming contract:** releases now publish exactly one asset, `ErrandDesktop.dmg` — no arch or version suffix. The Homebrew cask resolves `releases/download/v<version>/ErrandDesktop.dmg`, so renaming it breaks every install and upgrade.

## UpdateChecker

`repoPath` pointed at `errand/errand-desktop`, which 404s — no user has ever seen an update notification. Fixed to `errand-ai/errand-desktop`, with a test asserting the constructed URL, and the notification copy now leads with `brew upgrade --cask errand-desktop`.

## Spec correction worth reviewing

Homebrew 6 refuses to load casks from non-official taps until trusted (`HOMEBREW_REQUIRE_TAP_TRUST` is the default and `brew tap` does not prompt), so the documented install is three commands, not two. The spec's "Single-command install" requirement was reworded to "Architecture-agnostic install" and a new "Tap trust is a documented prerequisite" requirement added; proposal and design were synced to match.

Also fixes a stray `## ADDED Requirements` delta header in `openspec/specs/runtime-selection/spec.md` that hid all four of its requirements from validate/archive. **The other 11 main specs have the same defect** and will need the same fix before their changes can archive.

## Verification

- `swift build -c release` and `swift build -c release --arch x86_64` both clean
- `lipo -info` on the merged binary reports `x86_64 arm64`; both slices carry `minos 15.0`
- `swift test` — 62/62 pass
- `openspec validate homebrew-distribution` — valid

Not yet done: the cask push, the tagged release, and manual smoke tests on Intel/Sequoia/Tahoe hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)