### PR TITLE
Fix universal release signing: drop the in-bundle entitlements copy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,11 @@ jobs:
           </dict>
           </plist>
           PLIST
-          cp ErrandDesktop.entitlements "ErrandDesktop.app/Contents/"
+          # NB: do NOT copy ErrandDesktop.entitlements into Contents/. A loose file
+          # directly in Contents/ is treated by codesign as a subcomponent it must
+          # seal as code, which fails ("code object is not signed at all"). The
+          # entitlements are embedded into the signature from the repo-root copy via
+          # --entitlements below; nothing reads the file at runtime.
 
           # Create the resource bundle with app resources (icons, images).
           # SPM resources are excluded from the target; we manage the bundle ourselves
@@ -136,13 +140,17 @@ jobs:
         run: |
           # Sign the universal binary in place first, then the .app wrapper.
           # Both slices are covered by a single signature on the fat Mach-O.
-          codesign --force --verify --verbose \
+          #
+          # No --verify on these two: given a path inside a bundle, codesign verifies
+          # the enclosing bundle, which is not signed yet at this point. Verification
+          # happens once, below, after the wrapper is signed.
+          codesign --force --verbose \
             --sign "Developer ID Application" \
             --options runtime \
             --entitlements ErrandDesktop.entitlements \
             "ErrandDesktop.app/Contents/MacOS/ErrandDesktop"
 
-          codesign --force --verify --verbose \
+          codesign --force --verbose \
             --sign "Developer ID Application" \
             --options runtime \
             --entitlements ErrandDesktop.entitlements \
@@ -150,6 +158,15 @@ jobs:
 
           codesign -dvv "ErrandDesktop.app"
           codesign --verify --strict --verbose=2 "ErrandDesktop.app"
+
+          # The virtualization entitlement is what lets the app create VMs. If it is
+          # missing from the embedded signature, Apple Containerization is dead on
+          # arrival on Tahoe — and nothing else in the pipeline would notice.
+          if ! codesign -d --entitlements - --xml "ErrandDesktop.app" 2>/dev/null \
+               | grep -q "com.apple.security.virtualization"; then
+            echo "error: com.apple.security.virtualization missing from the signature" >&2
+            exit 1
+          fi
 
       - name: Create DMG
         run: |


### PR DESCRIPTION
The v0.5.0 release run ([33856068792](https://github.com/errand-ai/errand-desktop/actions/runs/33856068792)) failed at **Sign app bundle**:

```
ErrandDesktop.app/Contents/MacOS/ErrandDesktop: code object is not signed at all
In subcomponent: .../ErrandDesktop.app/Contents/ErrandDesktop.entitlements
```

No release was published — every step from Create DMG onward was skipped.

## Root cause

`cp ErrandDesktop.entitlements ErrandDesktop.app/Contents/` in the bundle step. A loose file directly in `Contents/` is treated by codesign as a subcomponent it must seal as code, and it cannot be. The previous `--deep` sign of the `.app` tolerated this — which is why v0.4.1 shipped — but signing the inner binary first does not.

My first guess (that the premature `--verify` was to blame) was wrong; removing it alone still fails. I reproduced against a byte-faithful replica of the CI bundle to separate the two:

| bundle | step 1 (inner) | step 2 (app) | `--verify --strict` |
| --- | --- | --- | --- |
| entitlements copied into `Contents/` | fail | fail | `code object is not signed at all` |
| entitlements **not** copied in | pass | pass | `valid on disk`, `satisfies its Designated Requirement` |

## The fix

- **Drop the copy.** It was never needed: entitlements are embedded into the signature from the repo-root copy via `--entitlements`, nothing reads the file at runtime, and `make run` has always signed without it. Confirmed embedded afterwards via `codesign -d --entitlements -`.
- **Drop `--verify` from the two signing invocations.** Given a path inside a bundle, codesign verifies the *enclosing bundle*, which isn't signed yet at step 1. Verification now happens once, after the wrapper is signed.
- **Add a guard** asserting `com.apple.security.virtualization` is present in the embedded signature. Without that entitlement the app cannot create VMs, so Apple Containerization would be dead on arrival on Tahoe — and no other step in the pipeline would notice.

Once merged I'll re-point the `v0.5.0` tag at the fixed commit and re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)