### PR TITLE
Set CFBundlePackageType=APPL in the CI app bundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
               <string>sh.errand.desktop</string>
               <key>CFBundleName</key>
               <string>ErrandDesktop</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
               <key>CFBundleVersion</key>
               <string>${VERSION}</string>
               <key>CFBundleShortVersionString</key>
@@ -104,6 +106,15 @@ jobs:
           MIN="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' 'ErrandDesktop.app/Contents/Info.plist')"
           if [[ "$MIN" != "15.0" ]]; then
             echo "error: LSMinimumSystemVersion is '$MIN', expected '15.0'" >&2
+            exit 1
+          fi
+
+          # Without CFBundlePackageType=APPL, Gatekeeper does not treat the bundle as
+          # an application: spctl --assess --type execute reports "the code is valid
+          # but does not seem to be an app".
+          PKG="$(/usr/libexec/PlistBuddy -c 'Print :CFBundlePackageType' 'ErrandDesktop.app/Contents/Info.plist')"
+          if [[ "$PKG" != "APPL" ]]; then
+            echo "error: CFBundlePackageType is '$PKG', expected 'APPL'" >&2
             exit 1
           fi
 


### PR DESCRIPTION
Notarization now works. The v0.5.0 run gets **Accepted** from Apple and staples cleanly, and the DMG passes Gatekeeper:

```
ErrandDesktop.dmg: accepted
source=Notarized Developer ID
```

The app assertion is the only thing left failing:

```
ErrandDesktop.app: rejected (the code is valid but does not seem to be an app)
```

## Cause

"The code is valid" — the signature and notarization are fine. It's the *app-ness* check failing, and the CI `Info.plist` has never set `CFBundlePackageType`. That key (`APPL`) is what identifies a bundle as an application to LaunchServices and Gatekeeper.

The `Makefile` has always set it for local dev; CI drifted:

| key | Makefile | CI (before this PR) |
| --- | --- | --- |
| `CFBundleIdentifier` | ✓ | ✓ |
| `CFBundleName` | ✓ | ✓ |
| `CFBundleExecutable` | ✓ | ✓ |
| `CFBundleIconFile` | ✓ | ✓ |
| `LSUIElement` | ✓ | ✓ |
| **`CFBundlePackageType`** | **✓** | **✗** |

This predates the universal-binary work — **v0.4.1 shipped without the key as well**. It went unnoticed because the old pipeline never ran `spctl`; the new verification step is what surfaced it.

## Honesty about the diagnosis

I could not fully reproduce this locally: without a Developer ID certificate my test bundle is ad-hoc signed, so `spctl` rejects it earlier and never emits the "does not seem to be an app" diagnostic that distinguishes this case. The evidence is the CI message itself ("the code is valid but…"), the Makefile/CI divergence, and Apple's documented meaning for the key. If it turns out not to be sufficient, the next thing to try is assessing the app *inside the mounted DMG* rather than the loose build-directory copy — that copy is signed but not stapled, so it relies on an online notarization lookup.

## Change

Adds the key, and asserts it survives into the built bundle alongside the existing universal-slice and `LSMinimumSystemVersion` assertions, so it cannot silently drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)