### PR TITLE
Add a Sequoia CI job and gate releases on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,52 @@ jobs:
       - name: Test
         run: swift test
 
+  # The self-hosted runner above is Tahoe. Since the app now deploys to macOS 15,
+  # build and run the tests on an actual Sequoia host too.
+  #
+  # Swift's availability checking keys off the deployment target, not the host, so
+  # ungated macOS 26 API is already a compile error on Tahoe. What this job adds is
+  # a *runtime* check: the test binary links the whole module, including
+  # AppleContainerRuntime, so if a macOS 26 symbol were ever referenced eagerly
+  # rather than behind `if #available`, the process would fail to load here and
+  # pass on Tahoe. It also proves a contributor on the minimum supported OS can
+  # build the repo at all.
+  build-sequoia:
+    name: Build & Test (Sequoia)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select Xcode 26
+        run: |
+          # The macos-15 image defaults to Xcode 16.4, whose Swift 6.1 cannot parse
+          # `swift-tools-version: 6.2`. Pick the newest Xcode 26.x present rather
+          # than pinning an exact version, since the image is updated regularly.
+          XCODE="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)"
+          if [[ -z "$XCODE" ]]; then
+            echo "error: no Xcode 26.x on this runner image." >&2
+            echo "swift-tools-version 6.2 requires it, and swift-containerization" >&2
+            echo "needs the macOS 26 SDK for its @available(macOS 26, *) symbols." >&2
+            ls -d /Applications/Xcode*.app >&2
+            exit 1
+          fi
+          echo "Selecting $XCODE"
+          sudo xcode-select -s "$XCODE"
+
+      - name: Show toolchain
+        run: |
+          sw_vers
+          swift --version
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test
+
   release:
     name: Release (universal)
-    needs: build-and-test
+    needs: [build-and-test, build-sequoia]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     # Apple Silicon runner: the x86_64 slice is cross-compiled, so no Intel runner
     # is required. The toolchain here must be able to target macOS 15 (Sequoia).


### PR DESCRIPTION
Closes the gap flagged in the `homebrew-distribution` design: the app now deploys to macOS 15, but every CI job runs on the self-hosted `m4-max` runner, which is Tahoe.

## Change

Adds `build-sequoia` on a GitHub-hosted `macos-15` runner (currently macOS 15.7.7, arm64) and makes `release` depend on it, so a Sequoia regression **blocks a release** rather than just annotating a PR.

```
build-and-test (m4-max, Tahoe) ─┐
                                ├─> release (m4-max)
build-sequoia  (macos-15)      ─┘
```

The image ships nine Xcode versions and **defaults to 16.4**, whose Swift 6.1 cannot parse `swift-tools-version: 6.2`. The job selects the newest `Xcode_26*.app` present — a glob rather than a pin, since the image is updated regularly — and fails with an explanatory message listing what *is* installed if none is found. Xcode 26.x is required regardless of host, because `swift-containerization` has 13 `@available(macOS 26, *)` declarations whose symbols only exist in the macOS 26 SDK.

## What this actually catches — and what it doesn't

Worth being precise, because the design's stated rationale was slightly off:

**It does not add compile-time availability checking.** Swift's availability checking keys off the *deployment target*, not the host OS. Since `Package.swift` says `.macOS(.v15)`, ungated macOS 26 API is already a compile error on Tahoe today — I confirmed the current build is clean under that constraint.

**What it does add:**

1. **A runtime check on the minimum OS.** The test binary links the whole module including `AppleContainerRuntime`. If a macOS 26 symbol were ever referenced eagerly rather than behind `if #available`, the process would fail to load on Sequoia and pass on Tahoe. Nothing else in CI can catch that.
2. **Proof the repo builds on the minimum supported OS.** No job did this before — contributors on Sequoia are now the floor of our support matrix.
3. **A clean-environment build,** independent of the self-hosted runner's cached state.

Free for this repo, since it's public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)