### PR TITLE
Repair all main specs: delta headers, a stray REMOVED block, and Purpose sections

### DIFF
--- a/openspec/changes/homebrew-distribution/tasks.md
+++ b/openspec/changes/homebrew-distribution/tasks.md
@@ -29,7 +29,7 @@
 - [x] 4.1 Create the public repository `errand-ai/homebrew-errand` on GitHub. Add a top-level `README.md` with the install/upgrade instructions.
 - [x] 4.2 Create `Casks/errand-desktop.rb` with `version`, `sha256`, `url` (pointing at `https://github.com/errand-ai/errand-desktop/releases/download/v#{version}/ErrandDesktop.dmg`), `name`, `desc`, `homepage`, `depends_on macos: ">= :sequoia"`, `app "ErrandDesktop.app"`, and a `livecheck` block targeting GitHub Releases.
 - [x] 4.3 Validate the cask locally with `brew style --fix Casks/errand-desktop.rb` and `brew audit --cask --new errand-desktop` (or equivalent) before pushing.
-- [ ] 4.4 End-to-end install verification: on a Mac that has never installed ErrandDesktop, run `brew tap errand-ai/errand && brew install --cask errand-desktop`, confirm `/Applications/ErrandDesktop.app` is present, and launch the app.
+- [x] 4.4 End-to-end install verification: on a Mac that has never installed ErrandDesktop, run `brew tap errand-ai/errand && brew install --cask errand-desktop`, confirm `/Applications/ErrandDesktop.app` is present, and launch the app.
 - [ ] 4.5 End-to-end upgrade verification: tag a patch release, confirm `brew upgrade --cask errand-desktop` picks up the new version on a previously-installed machine.
 
 ## 5. Documentation

--- a/openspec/specs/bridge-server-hardening/spec.md
+++ b/openspec/specs/bridge-server-hardening/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines the security posture of the local BridgeServer: which peers may connect, how requests are authenticated and bounded, and how its state is isolated.
+
+## Requirements
 
 ### Requirement: BridgeServer rejects connections from non-local peers
 The BridgeServer SHALL validate the remote address of every incoming TCP connection and immediately close connections that do not originate from 127.0.0.1 or the host's active vmnet gateway address. When the runtime exposes no numeric gateway address (Docker, whose gateway is the name `host.docker.internal`), the BridgeServer SHALL instead accept only peers whose address falls in an RFC 1918 private range.

--- a/openspec/specs/cloud-storage-desktop-services/spec.md
+++ b/openspec/specs/cloud-storage-desktop-services/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines how the Google Drive and OneDrive MCP servers are configured, toggled, launched, and health-checked as optional desktop services.
+
+## Requirements
 
 ### Requirement: Google Drive MCP server config toggle
 

--- a/openspec/specs/container-commands/spec.md
+++ b/openspec/specs/container-commands/spec.md
@@ -1,4 +1,7 @@
-## MODIFIED Requirements
+## Purpose
+Defines how services override a container's default command, and how ephemeral one-shot containers such as the migration runner are executed.
+
+## Requirements
 
 ### Requirement: Custom container command override
 Containers can be started with a custom command that overrides the image's default CMD. The command is passed through the active `ContainerRuntime` protocol rather than directly to Apple Containerization.

--- a/openspec/specs/container-runtime-abstraction/spec.md
+++ b/openspec/specs/container-runtime-abstraction/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines the runtime-agnostic ContainerRuntime protocol and the shared behaviour every backend must provide: image resolution, health checks, inter-container networking, and task-runner environment wiring.
+
+## Requirements
 
 ### Requirement: ContainerRuntime protocol
 The system SHALL define a `ContainerRuntime` protocol that abstracts all container lifecycle operations, allowing multiple backend implementations (Docker, Apple Containerization).

--- a/openspec/specs/docker-runtime/spec.md
+++ b/openspec/specs/docker-runtime/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines the Docker backend's implementation of the container runtime: Engine API access over the socket, container lifecycle, port publishing, volumes, networking, exec, and image pulls.
+
+## Requirements
 
 ### Requirement: Docker Engine API client
 The system SHALL communicate with the Docker Engine via its HTTP REST API over the Unix socket at `/var/run/docker.sock`.

--- a/openspec/specs/hindsight-service/spec.md
+++ b/openspec/specs/hindsight-service/spec.md
@@ -1,4 +1,7 @@
-## MODIFIED Requirements
+## Purpose
+Defines the environment the Hindsight memory service requires from the host app in order to start.
+
+## Requirements
 
 ### Requirement: Hindsight receives required environment variables
 The hindsight container SHALL receive environment variables for database access, LLM routing, and model configuration. LLM API keys SHALL be scoped hindsight service keys rather than the LiteLLM master key.

--- a/openspec/specs/litellm-service-keys/spec.md
+++ b/openspec/specs/litellm-service-keys/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines how per-service LiteLLM API keys and the Postgres password are provisioned, stored, injected into containers, and migrated, so that no service shares the master key.
+
+## Requirements
 
 ### Requirement: Service key provisioning after LiteLLM healthy
 The app SHALL generate two scoped LiteLLM virtual API keys via `POST /key/generate` after LiteLLM passes its health check, before any dependent service (Backend, Worker, Hindsight) starts.

--- a/openspec/specs/playwright-service/spec.md
+++ b/openspec/specs/playwright-service/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines the Playwright MCP container service: how it runs in isolated mode, how its health is checked, and how its URL reaches dependent services.
+
+## Requirements
 
 ### Requirement: Playwright MCP container service
 

--- a/openspec/specs/provider-detection/spec.md
+++ b/openspec/specs/provider-detection/spec.md
@@ -1,4 +1,7 @@
-## ADDED Requirements
+## Purpose
+Defines how the app probes a configured LLM endpoint to identify its provider type, when detection re-runs, and how the result is persisted.
+
+## Requirements
 
 ### Requirement: Provider type detection via HTTP probing
 The system SHALL detect the type of an external LLM provider by probing its HTTP endpoints. Detection SHALL try LiteLLM first, then OpenAI-compatible, then fall back to unknown.

--- a/openspec/specs/runtime-selection/spec.md
+++ b/openspec/specs/runtime-selection/spec.md
@@ -1,3 +1,6 @@
+## Purpose
+Defines how the app detects, presents, and persists the choice of container runtime.
+
 ## Requirements
 
 ### Requirement: Runtime auto-detection

--- a/openspec/specs/setup-wizard-hindsight-flow/spec.md
+++ b/openspec/specs/setup-wizard-hindsight-flow/spec.md
@@ -1,4 +1,7 @@
-## MODIFIED Requirements
+## Purpose
+Defines the Agent Memory step of the setup wizard: how model dropdowns are populated and filtered from the LLM endpoint, and how the choices reach the Hindsight container and the Settings tab.
+
+## Requirements
 
 ### Requirement: Agent Memory step in setup wizard
 The setup wizard SHALL include an Agent Memory step with a "Use Hindsight for Agent Memory" toggle that defaults to on. A brief description SHALL explain that Hindsight provides persistent memory for AI agents, with a link to https://errand.sh/docs/ai-memory/ for more information.

--- a/openspec/specs/setup-wizard-litellm-flow/spec.md
+++ b/openspec/specs/setup-wizard-litellm-flow/spec.md
@@ -1,4 +1,7 @@
-## MODIFIED Requirements
+## Purpose
+Defines the LLM step of the setup wizard: the LiteLLM toggle and its conditional fields, inline container startup, indexed provider env vars, and how Settings mirrors the wizard.
+
+## Requirements
 
 ### Requirement: LiteLLM is enabled by default in setup wizard
 The LLM Configuration step SHALL display a radio choice between "Deploy LiteLLM locally" (selected by default, recommended) and "Connect to an existing provider". A brief description SHALL explain the choice, with a link to https://errand.sh/docs/ai-models/ for more information.
@@ -116,9 +119,3 @@ The setup wizard SHALL have the same number of steps as currently, with the LLM 
 #### Scenario: Step indicator reflects current flow
 - **WHEN** the setup wizard is displayed
 - **THEN** the step indicator reflects the total steps, hiding the LiteLLM startup step when deploying locally is not selected
-
-## REMOVED Requirements
-
-### Requirement: LiteLLM disabled falls back to direct config
-**Reason**: Replaced by indexed `LLM_PROVIDER_0_*` env var injection for all provider modes. The old `OPENAI_BASE_URL`/`OPENAI_API_KEY` format is no longer used by errand-server.
-**Migration**: Backend and worker containers now receive `LLM_PROVIDER_0_NAME`, `LLM_PROVIDER_0_BASE_URL`, and `LLM_PROVIDER_0_API_KEY` regardless of deployment mode.


### PR DESCRIPTION
Every main spec in `openspec/specs/` was structurally invalid and had been since the first archive run. `openspec validate --specs` went **0 passed / 12 failed → 12 passed / 0 failed**, and `openspec list --specs` went **0 requirements → 72 across 12 specs**.

## Three separate defects

**1. Delta headers in main specs (all 12).** Every file began with `## ADDED Requirements` or `## MODIFIED Requirements`, left behind by past archive runs. Those headers are only valid inside a change's `specs/` directory; in a main spec they truncate the parsed `## Requirements` section, which is why archive refused to update them.

**2. Missing `## Purpose` (all 12).** Fixing the headers alone was *not* enough — I checked, and all twelve still reported zero requirements. openspec only parses requirements in a spec that also has a Purpose section. Each now carries a one-line purpose derived from its own requirements, not invented.

**3. A stray `## REMOVED Requirements` block** at the end of `setup-wizard-litellm-flow`, documenting *LiteLLM disabled falls back to direct config* as removed. A removed requirement should simply be absent from a main spec rather than recorded as present-but-removed, so the section is dropped. Its stated reason — replaced by indexed `LLM_PROVIDER_0_*` env var injection — remains recorded in the change that removed it.

## Verification

| | before | after |
| --- | --- | --- |
| `openspec validate --specs` | 0 passed, 12 failed | **12 passed, 0 failed** |
| `openspec list --specs` | 0 requirements | **72 requirements** |

The three in-flight changes still validate: `homebrew-distribution`, `converge-provider-config`, `shared-workspace-mounts`.

Also marks task 4.4 (clean-Mac `brew install` verification) complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)